### PR TITLE
Raschii version 2

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   install-and-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,7 +26,7 @@ jobs:
         run: pip3 install "pybind11[global]"
 
       - name: Install Raschii with its dependencies
-        run: pip3 install .
+        run: pip3 install ".[plot]"
 
       - name: Run unit tests with system Python
         env:
@@ -50,7 +50,7 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies with uv
-        run: uv sync
+        run: uv sync --extra plot
 
       - name: Run unit tests with uv
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 *.swd
 .venv
 uv.lock
+tmp_*

--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,9 @@ A few **backwards incompatible** changes were made in this release:
   ``wave.cpp.velocity``. This reduces the size of the main wave classes and keeps little-used
   functionality separate from the main code base.
 
+- Bumped minimum version of Python to 3.11 (first release in 2022) and the minimum version of our
+  only dependency, numpy, to 2.2 (first release in 2024).
+
 Version 1.2.0 - July 3. 2026
 ............................
 

--- a/README.rst
+++ b/README.rst
@@ -83,9 +83,9 @@ This will output:
 
 .. code:: output
 
-    [0.67352456]
+    0.67352456
     [0.67352456 0.61795882 0.57230232 0.53352878]
-    [[0.27263788 0.        ]]
+    [0.27263788 0.        ]
 
 See the `documentation <https://raschii.readthedocs.io/en/latest/usage.html>`_ for more
 information on the available parameters, methods and attributes of the wave classes.
@@ -147,6 +147,27 @@ Raschii is automatically tested using pytest and GitHub Actions and the current 
 
 Releases
 --------
+
+Version 2.0.0 - July 3. 2026
+............................
+
+New features:
+
+- More vectorization of inputs are now possible. Thanks to jasperpato in `pull request #7
+  <https://github.com/TormodLandet/raschii/pull/7>`_! In addition TormodLandet has added a few more
+  vectorized methods and changed the output shape of some methods for consistency (see below).
+
+A few **backwards incompatible** changes were made in this release:
+
+- Rename class ``RasciiError`` to ``RaschiiError``
+- Return scalar surface elevation (and velocity potential) when the input are all scalar.
+  If you give ``(x=1.0, t=0.0)``, the return value will be a scalar, but if you give
+  ``(x=[1.0], t=0.0)`` the return value will be a 1D array with one element. This is the same
+  as, e.g., numpy and scipy do for their functions, and is hence a bit more consistent.
+- Move the ``*_cpp`` methods to a separate ``raschii.cpp`` module. If you are one of the extremely
+  few users of the C++ code generator you must replace, e.g., ``wave.velocity_cpp`` with the new
+  ``wave.cpp.velocity``. This reduces the size of the main wave classes and keeps little-used
+  functionality separate from the main code
 
 Version 1.2.0 - July 3. 2026
 ............................

--- a/README.rst
+++ b/README.rst
@@ -153,24 +153,38 @@ Version 2.0.0 - July 3. 2026
 
 New features:
 
-- More vectorization of inputs are now possible. Thanks to jasperpato in `pull request #7
-  <https://github.com/TormodLandet/raschii/pull/7>`_! In addition TormodLandet has added a few more
-  vectorized methods and changed the output shape of some methods for consistency (see below).
+- More vectorization of inputs is now implemented, you can compute elevations and velocities for
+  multiple positions and multiple time steps at the same time. Thanks to jasperpato in
+  `pull request #7 <https://github.com/TormodLandet/raschii/pull/7>`_!
+  
+  In addition TormodLandet has added a few more vectorized methods and changed the output shape of
+  some methods for consistency (see below).
 
 A few **backwards incompatible** changes were made in this release:
 
-- Rename class ``RasciiError`` to ``RaschiiError``
+- Rename class ``RasciiError`` to ``RaschiiError``. Also thanks to jasperpato for spotting the
+  typo in the class name in `pull request #7 <https://github.com/TormodLandet/raschii/pull/7>`_.
+
 - Return scalar surface elevation (and velocity potential) when the input are all scalar.
-  If you give ``(x=1.0, t=0.0)``, the return value will be a scalar, but if you give
-  ``(x=[1.0], t=0.0)`` the return value will be a 1D array with one element. This is the same
-  as, e.g., numpy and scipy do for their functions, and is hence a bit more consistent.
+  If you give arguments ``(x=1.0, t=0.0)``, the return value will be a scalar, but if you give
+  arguments ``(x=[1.0], t=0.0)`` the return value will be a 1D array with one element.
+  
+  This is the same convention as used by numpy, and is a bit more consistent now that we support
+  more vectorized operations.
+
+- Wave-model-class constructors arguments: only height, depth, and length are allowed to be
+  positional, all other arguments (N, period etc) must be keyword arguments.
+
 - Move the ``*_cpp`` methods to a separate ``raschii.cpp`` module. If you are one of the extremely
   few users of the C++ code generator you must replace, e.g., ``wave.velocity_cpp`` with the new
   ``wave.cpp.velocity``. This reduces the size of the main wave classes and keeps little-used
-  functionality separate from the main code
+  functionality separate from the main code base.
 
 Version 1.2.0 - July 3. 2026
 ............................
+
+This is likely the last release of Raschii 1.x. The next release will be Raschii 2.0, which will
+include some breaking changes to the API and will require Python 3.12 or newer.
 
 - Support for writing ``amp=2`` and ``amp=3`` SWD files.
 - Support for calculating the velocity potential.

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,13 @@ Raschii is automatically tested using pytest and GitHub Actions and the current 
 Releases
 --------
 
+Version 1.2.0 - July 3. 2026
+............................
+
+- Support for writing ``amp=2`` and ``amp=3`` SWD files.
+- Support for calculating the velocity potential.
+- Refactored SWD writer and tests. 
+
 Version 1.1.1 - Unreleased
 ............................
 

--- a/README.rst
+++ b/README.rst
@@ -168,6 +168,11 @@ A few **backwards incompatible** changes were made in this release:
 - Rename class ``RasciiError`` to ``RaschiiError``. Also thanks to jasperpato for spotting the
   typo in the class name in `pull request #7 <https://github.com/TormodLandet/raschii/pull/7>`_.
 
+- Rename attribute ``T`` to ``period`` for the wave classes. The classes allready have attrubutes
+  named the same as the constructor inputs: ``height``, ``depth``, and ``length``. The attribute was
+  the odd one out that did not match the constructor input name. Other short-name attributes like
+  the celerity attribute ``c`` are not renamed since they are not constructor inputs.
+
 - Return scalar surface elevation (and velocity potential) when the input are all scalar.
   If you give arguments ``(x=1.0, t=0.0)``, the return value will be a scalar, but if you give
   arguments ``(x=[1.0], t=0.0)`` the return value will be a 1D array with one element.
@@ -182,6 +187,10 @@ A few **backwards incompatible** changes were made in this release:
   few users of the C++ code generator you must replace, e.g., ``wave.velocity_cpp`` with the new
   ``wave.cpp.velocity``. This reduces the size of the main wave classes and keeps little-used
   functionality separate from the main code base.
+
+- Other internal API renames and moves. The wave classes are moved to different module names which
+  is not considered a breaking change since the wave classes should be imported directly from the
+  ``raschii`` module, e.g. ``from raschii import FentonWave``.
 
 - Bumped minimum version of Python to 3.11 (first release in 2022) and the minimum version of our
   only dependency, numpy, to 2.2 (first release in 2024).

--- a/README.rst
+++ b/README.rst
@@ -114,8 +114,11 @@ An example of using Raschii from the command line:
   # Some information about the wave is also shown
   python -m raschii.cmd.plot -N 5 Fenton 0.2 1.5 2
 
+  # The same, specified by wave period instead of wave length
+  python -m raschii.cmd.plot -N 5 --period 1.2 Fenton 0.2 1.5
+
   # Save the same stream function wave to a SWD file
-  python -m raschii.cmd.swd -N 5 fenton.swd Fenton 0.2 1.5 2  
+  python -m raschii.cmd.swd -N 5 fenton.swd Fenton 0.2 1.5 2
 
 The plot tool allows comparing multiple waves, the SWD file writer only
 supports a single wave at a time and does currently not support Airy waves.
@@ -148,7 +151,7 @@ Raschii is automatically tested using pytest and GitHub Actions and the current 
 Releases
 --------
 
-Version 2.0.0 - July 3. 2026
+Version 2.0.0 - July ?. 2026
 ............................
 
 New features:

--- a/demos/wave2fenics.py
+++ b/demos/wave2fenics.py
@@ -111,7 +111,7 @@ def make_vel_div(wave, mesh, t):
     vel = dolfin.as_vector([u0, u1])
 
     # Get C++ expressions and convert to x-y plane from x-z plane
-    cpp_x, cpp_y = wave.velocity_cpp()
+    cpp_x, cpp_y = wave.cpp.velocity()
     cpp_x = cpp_x.replace("x[2]", "x[1]")
     cpp_y = cpp_y.replace("x[2]", "x[1]")
 
@@ -144,7 +144,7 @@ def make_colour_function(wave, mesh, t):
     element = dolfin.FiniteElement(
         "Quadrature", mesh.ufl_cell(), quad_degree, quad_scheme="default"
     )
-    ec = dolfin.Expression("x[1] < (%s) ? 1.0 : 0.0" % wave.elevation_cpp(), element=element, t=t)
+    ec = dolfin.Expression("x[1] < (%s) ? 1.0 : 0.0" % wave.cpp.elevation(), element=element, t=t)
     u0, v0 = dolfin.TrialFunction(V0), dolfin.TestFunction(V0)
     c = dolfin.Function(V0)
     A0 = dolfin.assemble(u0 * v0 * dolfin.dx)

--- a/documentation/_static/raschii_pyscript.py
+++ b/documentation/_static/raschii_pyscript.py
@@ -71,7 +71,7 @@ def plot_wave():
         f"  Horizontal trough particle speed = {Ut[0]:.3f}",
         f"  Wave number    = {wave.k:.5f}",
         f"  Wave frequency = {wave.omega:.5f}",
-        f"  Wave period    = {wave.T:.2f}",
+        f"  Wave period    = {wave.period:.2f}",
         f"  Phase speed    = {wave.c:.3f}",
         "",
         "Numerical details:",

--- a/documentation/_static/raschii_pyscript.py
+++ b/documentation/_static/raschii_pyscript.py
@@ -101,14 +101,14 @@ def show_info_when_clicking_plot(mouse_event):
 
     # Show the information about the clicked point
     info = f"You clicked on x = {x:.3f} m, z = {z:.3f} m (from the bottom)"
-    eta = current_raschii_wave.surface_elevation(x=[x], t=0.0)[0]
+    eta = current_raschii_wave.surface_elevation(x, t=0.0)
     if z > eta:
         info += "<br>(Air)"
     else:
         info += "<br>(Water)"
         vel = current_raschii_wave.velocity(x, z, all_points_wet=True)
-        info += f"<br>Horizontal particle velocity: {vel[0, 0]:.3f}"
-        info += f"<br>Vertical particle velocity:   {vel[0, 1]:.3f}"
+        info += f"<br>Horizontal particle velocity: {vel[0]:.3f}"
+        info += f"<br>Vertical particle velocity:   {vel[1]:.3f}"
 
     page.find("#raschii p.info").innerHTML = info
 

--- a/documentation/api_docs.rst
+++ b/documentation/api_docs.rst
@@ -80,6 +80,6 @@ construct consistent initial and boundary conditions.
 Exceptions
 =================
 
-.. autoexception:: raschii.RasciiError
+.. autoexception:: raschii.RaschiiError
 
 .. autoexception:: raschii.NonConvergenceError

--- a/documentation/api_docs.rst
+++ b/documentation/api_docs.rst
@@ -22,6 +22,71 @@ Main functions
 .. .. autodata:: raschii.__version__
 
 
+Wave model API summary
+======================
+
+All three wave model classes (:class:`~raschii.AiryWave`,
+:class:`~raschii.StokesWave`, and :class:`~raschii.FentonWave`) share the
+following attributes and methods.
+
+.. list-table:: Attributes and methods available on all wave models
+   :widths: 45 55
+   :header-rows: 1
+
+   * - Attribute / Method
+     - Description
+   * - ``height``, ``depth``, ``length``, ``g``
+     - Input parameters, stored as instance attributes.
+   * - ``T``
+     - Wave period [s].
+   * - ``omega``
+     - Angular frequency [rad/s].
+   * - ``k``
+     - Wave number [1/m].
+   * - ``c``
+     - Phase speed [m/s].
+   * - ``warnings``
+     - String with any warnings raised during construction (empty if none).
+   * - ``surface_elevation(x, t=0, include_depth=True)``
+     - Free-surface elevation.  Returns a scalar when both *x* and *t* are
+       scalar, an ndarray otherwise (NumPy scalar-in / scalar-out convention).
+   * - ``velocity(x, z, t=0, all_points_wet=False)``
+     - Fluid velocity at each *(x, z)* point.  Shape ``(2,)`` for scalar inputs,
+       ``(N, 2)`` or ``(T, N, 2)`` for array inputs.
+   * - ``velocity_potential(x, z, t=0)``
+     - Earth-frame velocity potential φ (mean flow excluded).  Same scalar/array
+       convention as ``surface_elevation``.
+   * - ``write_swd(path, dt, tmax=None, nperiods=None, amp=1)``
+     - Write the wave field to a file in the
+       `SWD format <https://spectral-wave-data.readthedocs.io/>`_.
+   * - ``cpp``
+     - C++ code generator (experimental — see :ref:`cpp-code-generation`).
+
+The following methods are only available on specific wave model classes.
+
+.. list-table:: Methods available on specific wave models only
+   :widths: 38 42 20
+   :header-rows: 1
+
+   * - Method
+     - Description
+     - Available on
+   * - ``stream_function(x, z, t=0, frame=Frame.EARTH)``
+     - Stream function ψ.  Use :class:`~raschii.Frame` to choose the reference
+       frame (``Frame.EARTH`` or ``Frame.WAVE``).
+     - :class:`~raschii.FentonWave`
+   * - ``surface_slope(x, t=0)``
+     - Horizontal derivative dη/dx of the free-surface elevation.
+     - :class:`~raschii.FentonWave`
+   * - ``acceleration(x, z, t=0, all_points_wet=False)``
+     - Fluid acceleration.  Water-phase only; returns zero above the free
+       surface (air blending is not yet implemented for accelerations).
+     - :class:`~raschii.FentonWave`
+   * - ``cs``
+     - Mean Stokes drift speed [m/s].
+     - :class:`~raschii.FentonWave`, :class:`~raschii.StokesWave`
+
+
 Wave model classes
 ==================
 
@@ -78,8 +143,38 @@ construct consistent initial and boundary conditions.
 
 
 Exceptions
-=================
+==========
 
 .. autoexception:: raschii.RaschiiError
 
 .. autoexception:: raschii.NonConvergenceError
+
+
+Enumerations
+============
+
+.. autoclass:: raschii.Frame
+    :members:
+
+
+Other
+=====
+
+
+.. _cpp-code-generation:
+
+C++ code generators
+-------------------
+
+Each wave model exposes a ``wave.cpp`` attribute that can generate C++ code
+strings for use in e.g. FEniCS boundary conditions.  The available methods are
+``wave.cpp.elevation()``, ``wave.cpp.velocity()``, ``wave.cpp.stream_function()``,
+and ``wave.cpp.slope()`` (the last two are implemented only for
+:class:`~raschii.FentonWave`).
+
+.. warning::
+
+   The C++ code generation interface (``wave.cpp.*``) is **experimental**.
+   Its API may change or be removed in a future release without following the
+   normal deprecation cycle. It is currently not used by anyone as far as the
+   author of Raschii is aware.

--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -32,7 +32,7 @@ import raschii
 # -- Project information -----------------------------------------------------
 
 project = "raschii"
-copyright = "2018-2024, Tormod Landet"
+copyright = "2018-2026, Tormod Landet"
 author = "Tormod Landet"
 
 # The full version, including alpha/beta/rc tags

--- a/documentation/theory.rst
+++ b/documentation/theory.rst
@@ -119,9 +119,10 @@ manner.
 ConstantAir
 ===========
 
-The velocity in the air phase is horizontal with speed equal to the wave phase
-speed. This is mostly useful when using a blended total field, see
-:ref:`sec_blending`.
+The air is at rest in the earth frame (zero velocity). This is the simplest
+possible air-phase model and is a reasonable approximation when the air motion
+is negligible compared to the water-phase velocities. The wave-frame stream
+function contains a backward drift at the wave phase speed.
 
 
 FentonAir

--- a/documentation/usage_command_line.rst
+++ b/documentation/usage_command_line.rst
@@ -26,29 +26,41 @@ to see the options. At the time of writing, the output is
 
 .. code:: text
 
-  usage: raschii.cmd.swd [-h] [-N N] [--dt DT] [--tmax TMAX] [--swd-amp {1,2,3}] [-f]
-                         swd_file     wave_type
-                         wave_height  water_depth  wave_length
+  usage: raschii.cmd.swd [-h] [-T PERIOD] [-N N] [--dt DT] [--tmax TMAX]
+                         [--swd-amp {1,2,3}] [-f]
+                         swd_file wave_type wave_height water_depth [wave_length]
 
   Write a Raschii wave to file (SWD format)
 
   positional arguments:
-    swd_file           Name of the SWD file to write.
-    wave_type          Name of the wave model.
-    wave_height        Wave height
-    water_depth        The still water depth
-    wave_length        Distance between peaks
+    swd_file              Name of the SWD file to write.
+    wave_type             Name of the wave model.
+    wave_height           Wave height
+    water_depth           The still water depth
+    wave_length           Distance between wave crests. Mutually exclusive with
+                          --period / -T.
 
   options:
-    -h, --help         show this help message and exit
-    -N N               Approximation order
-    --dt DT            Timestep
-    --tmax TMAX        Duration
-    --swd-amp {1,2,3}  SWD amp flag.
-                       1 (default): store potential at z=0 (calm surface);
-                       2: store potential on the wavy free surface;
-                       3: store elevation only (no potential).
-    -f, --force        Allow exceeding breaking criteria
+    -h, --help            show this help message and exit
+    -T PERIOD, --period PERIOD
+                          Wave period in seconds (alternative to the positional
+                          wave_length argument).
+    -N N                  Approximation order
+    --dt DT               Timestep
+    --tmax TMAX           Duration
+    --swd-amp {1,2,3}     SWD amp flag.
+                          1 (default): store potential at z=0 (calm surface);
+                          2: store potential on the wavy free surface;
+                          3: store elevation only (no potential).
+    -f, --force           Allow exceeding breaking criteria
+
+Examples::
+
+    # Write by wave length
+    python -m raschii.cmd.swd -N 5 fenton.swd Fenton 0.2 1.5 2
+
+    # Write by wave period
+    python -m raschii.cmd.swd -N 5 --period 1.2 fenton.swd Fenton 0.2 1.5
 
 
 Basic plots
@@ -58,10 +70,14 @@ Raschii can create basic plots of the wave elevation and kinematics.
 This only works if you separately install the `matplotlib` package which is not a required
 dependency of Raschii since it is not needed for the main functionality.
 
-To plot a wave, run
+To plot a wave by wave length, run
 
 .. code:: bash
 
     python -m raschii.cmd.plot Fenton 10 100 100 --velocities --ymin 50
+
+To plot a wave by wave period instead, use ``--period`` / ``-T``::
+
+    python -m raschii.cmd.plot -T 8 Fenton 10 100 --velocities
 
 Use ``--help`` to see all options. Two plot windows should pop up on your screen.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,11 @@ Homepage = "https://github.com/TormodLandet/raschii"
 Source = "https://github.com/TormodLandet/raschii"
 Documentation = "https://raschii.readthedocs.io/"
 
+[project.optional-dependencies]
+plot = [
+    "matplotlib >= 3.9",
+]
+
 [dependency-groups]
 test = [
     "pytest >= 8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,16 @@ description = "A Python implementation of nonlinear regular wave theories (Stoke
 readme = "README.rst"
 authors = [{name = "Tormod Landet", email = "tormod@landet.net"}]
 license = "apache-2.0"
-requires-python = ">=3.10"  # numpy 2.1 dropped 3.9 and below
-dependencies = ["numpy"]
+
+# Python version 3.11 is needed for StrEnum.
+# Python version 3.10 is end-of-life in October 2026 anyways (change made in July 2026).
+requires-python = ">=3.11"
+
+# We keep dependencies to a minimum. Doing this also allows us easy use on the web.
+# See the PyScript version of Raschii in documentation/_static/raschii_pyscript (html and py files)
+dependencies = [
+    "numpy >= 2.2",  # Numpy 2.2 is supported until December 2026 (version bump made in July 2026).
+]
 
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -52,4 +60,4 @@ line-length = 100
 
 [tool.black]
 line-length = 100
-target-version = ['py311']
+target-version = ['py312']

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -13,7 +13,7 @@ version = __version__
 
 from typing import Union, Tuple, Optional
 
-from .common import check_breaking_criteria, RasciiError, NonConvergenceError  # NOQA
+from .common import check_breaking_criteria, RaschiiError, NonConvergenceError  # NOQA
 from .airy import AiryWave
 from .fenton import FentonWave
 from .stokes import StokesWave
@@ -39,7 +39,7 @@ def get_wave_model(
         model_name, air_model_name = model_name.split("+")
 
     if model_name not in WAVE_MODELS:
-        raise RasciiError(
+        raise RaschiiError(
             "Wave model %r is not supported, supported wave "
             "models are %s" % (model_name, ", ".join(WAVE_MODELS.keys()))
         )
@@ -49,7 +49,7 @@ def get_wave_model(
         return wave, None
 
     if air_model_name not in AIR_MODELS:
-        raise RasciiError(
+        raise RaschiiError(
             "Air model %r is not supported, supported air phase "
             "models are %s" % (air_model_name, ", ".join(AIR_MODELS.keys()))
         )

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -11,9 +11,8 @@ SPDX-License-Identifier: Apache-2.0
 __version__ = "1.2.0"
 version = __version__
 
-from typing import Union, Tuple, Optional
-
-from .common import check_breaking_criteria, RaschiiError, NonConvergenceError  # NOQA
+from .common import check_breaking_criteria, RaschiiError, NonConvergenceError
+from .base_classes import WaveModel
 from .airy import AiryWave
 from .fenton import FentonWave
 from .stokes import StokesWave
@@ -32,10 +31,13 @@ RasciiError = RaschiiError
 
 
 def get_wave_model(
-    model_name: str, air_model_name: Optional[str] = None
-) -> Tuple[Union[AiryWave, StokesWave, FentonWave], Union[FentonAirPhase, ConstantAirPhase]]:
+    model_name: str, air_model_name: str | None = None
+) -> tuple[
+    type[AiryWave] | type[StokesWave] | type[FentonWave],
+    type[FentonAirPhase] | type[ConstantAirPhase] | None,
+]:
     """
-    Get a Raschii wave model by name
+    Get a Raschii wave model by name (returns the class, not an instance)
     """
     if "+" in model_name:
         assert air_model_name is None

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 #: The three-digit version number of Raschii
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 version = __version__
 
 from typing import Union, Tuple, Optional

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -26,9 +26,6 @@ WAVE_MODELS = {"Airy": AiryWave, "Fenton": FentonWave, "Stokes": StokesWave}
 #: The available air-phase models. A dictionary mapping model name (str) to model class.
 AIR_MODELS = {"FentonAir": FentonAirPhase, "ConstantAir": ConstantAirPhase}
 
-# For backwards compatibility with old, misspelled version of the RaschiiError class name
-RasciiError = RaschiiError
-
 
 def get_wave_model(
     model_name: str, air_model_name: str | None = None

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -7,12 +7,14 @@ raschii, the Arctic Krill.
 SPDX-License-Identifier: Apache-2.0
 """
 
+from typing import overload
+
 #: The three-digit version number of Raschii
 __version__ = "1.2.0"
 version = __version__
 
 from .common import check_breaking_criteria, RaschiiError, NonConvergenceError
-from .base_classes import WaveModel
+from .base_classes import Frame, WaveModel, AirPhaseModel
 from .airy import AiryWave
 from .fenton import FentonWave
 from .stokes import StokesWave
@@ -21,17 +23,34 @@ from .air_phase_constant import ConstantAirPhase
 
 
 #: The available wave models. A dictionary mapping model name (str) to model class.
-WAVE_MODELS = {"Airy": AiryWave, "Fenton": FentonWave, "Stokes": StokesWave}
+WAVE_MODELS: dict[str, type[WaveModel]] = {
+    "Airy": AiryWave,
+    "Fenton": FentonWave,
+    "Stokes": StokesWave,
+}
 
 #: The available air-phase models. A dictionary mapping model name (str) to model class.
-AIR_MODELS = {"FentonAir": FentonAirPhase, "ConstantAir": ConstantAirPhase}
+AIR_MODELS: dict[str, type[AirPhaseModel]] = {
+    "FentonAir": FentonAirPhase,
+    "ConstantAir": ConstantAirPhase,
+}
+
+
+@overload
+def get_wave_model(
+    model_name: str, air_model_name: str
+) -> tuple[type[WaveModel], type[AirPhaseModel]]: ...
+
+
+@overload
+def get_wave_model(model_name: str, air_model_name: None) -> tuple[type[WaveModel], None]: ...
 
 
 def get_wave_model(
     model_name: str, air_model_name: str | None = None
 ) -> tuple[
-    type[AiryWave] | type[StokesWave] | type[FentonWave],
-    type[FentonAirPhase] | type[ConstantAirPhase] | None,
+    type[WaveModel],
+    type[AirPhaseModel] | None,
 ]:
     """
     Get a Raschii wave model by name (returns the class, not an instance)

--- a/raschii/__init__.py
+++ b/raschii/__init__.py
@@ -10,14 +10,14 @@ SPDX-License-Identifier: Apache-2.0
 from typing import overload
 
 #: The three-digit version number of Raschii
-__version__ = "1.2.0"
+__version__ = "2.0.0rc1"
 version = __version__
 
 from .common import check_breaking_criteria, RaschiiError, NonConvergenceError
 from .base_classes import Frame, WaveModel, AirPhaseModel
-from .airy import AiryWave
-from .fenton import FentonWave
-from .stokes import StokesWave
+from .wave_airy import AiryWave
+from .wave_fenton import FentonWave
+from .wave_stokes import StokesWave
 from .air_phase_fenton import FentonAirPhase
 from .air_phase_constant import ConstantAirPhase
 

--- a/raschii/air_phase_constant.py
+++ b/raschii/air_phase_constant.py
@@ -1,11 +1,17 @@
 import numpy as np
-from .common import AIR_BLENDING_HEIGHT_FACTOR, np2py
+
+from .common import AIR_BLENDING_HEIGHT_FACTOR, Frame
+from .base_classes import AirPhaseModel
 
 
-class ConstantAirPhase:
+class ConstantAirPhase(AirPhaseModel):
     def __init__(self, height, blending_height=None):
         """
-        Constant horizontal velocity equal to the phase speed
+        Air phase model with zero velocity in the earth frame (still air).
+
+        The wave-frame stream function contains a backward drift at the wave
+        phase speed, which allows divergence-free blending with the water-phase
+        velocity field across the free surface.
         """
         self.height = height
         self.blending_height = blending_height
@@ -21,20 +27,28 @@ class ConstantAirPhase:
             self.blending_height = AIR_BLENDING_HEIGHT_FACTOR * wave.height
 
         from .cpp import ConstantAirCppGenerator
+
         self.cpp = ConstantAirCppGenerator(self)
 
-    def stream_function(self, x, z, t=0, frame="b"):
+    def stream_function(self, x, z, t=0, frame=Frame.EARTH):
         """
-        Compute the stream function at time t for position(s) x
+        Compute the stream function at time t for position(s) x.
+
+        * frame: :class:`~raschii.Frame` – ``Frame.EARTH`` (default) returns
+          zero (still air in the earth frame); ``Frame.WAVE`` returns ``-c*z``
+          (air appears to move backward at the wave phase speed in the
+          co-moving frame).
         """
         if isinstance(x, (float, int)):
             x, z = [x], [z]
         z = np.asarray(z, dtype=float)
 
-        if frame == "e":
-            return self.c * z
-        elif frame == "c":
-            return 0.0 * z
+        if frame == Frame.EARTH:
+            return np.zeros_like(z)
+        elif frame == Frame.WAVE:
+            return -self.c * z
+        else:
+            raise ValueError(f"Unknown frame {frame!r}; use Frame.EARTH or Frame.WAVE")
 
     def velocity(self, x, z, t=0):
         """

--- a/raschii/air_phase_constant.py
+++ b/raschii/air_phase_constant.py
@@ -20,6 +20,9 @@ class ConstantAirPhase:
         if self.blending_height is None:
             self.blending_height = AIR_BLENDING_HEIGHT_FACTOR * wave.height
 
+        from .cpp import ConstantAirCppGenerator
+        self.cpp = ConstantAirCppGenerator(self)
+
     def stream_function(self, x, z, t=0, frame="b"):
         """
         Compute the stream function at time t for position(s) x
@@ -46,29 +49,6 @@ class ConstantAirPhase:
         z = np.asarray(z, dtype=float)
 
         return np.zeros((x.size, 2), float)
-
-    def stream_function_cpp(self, frame="b"):
-        """
-        Return C++ code for evaluating the stream function of this specific
-        wave. The positive traveling direction is x[0] and the vertical
-        coordinate is x[2] which is zero at the bottom and equal to +depth at
-        the mean water level.
-        """
-        if frame == "b":
-            return f"{np2py(self.c)!r} * x[2]"
-        elif frame == "c":
-            return "0.0"
-
-    def velocity_cpp(self):
-        """
-        Return C++ code for evaluating the particle velocities of this specific
-        wave. Returns the x and z components only with z positive upwards. The
-        positive traveling direction is x[0] and the vertical coordinate is x[2]
-        which is zero at the bottom and equal to +depth at the mean water level.
-        """
-        cpp_x = "0.0"
-        cpp_z = "0.0"
-        return (cpp_x, cpp_z)
 
     def __repr__(self):
         return f"ConstantAirPhase(height={self.height}, blending_height={self.blending_height})"

--- a/raschii/air_phase_fenton.py
+++ b/raschii/air_phase_fenton.py
@@ -30,6 +30,9 @@ class FentonAirPhase:
         if self.blending_height is None:
             self.blending_height = AIR_BLENDING_HEIGHT_FACTOR * wave.height
 
+        from .cpp import FentonAirCppGenerator
+        self.cpp = FentonAirCppGenerator(self)
+
     def stream_function(self, x, z, t=0, frame="b"):
         """
         Compute the stream function at time t for position(s) x
@@ -79,73 +82,6 @@ class FentonAirPhase:
         vel[:, 1] = (k * B * sin(J * k * x2) * sinh(J * k * z2) / cosh(J * k * D)).dot(J)
 
         return vel
-
-    def stream_function_cpp(self, frame="b"):
-        """
-        Return C++ code for evaluating the stream function of this specific
-        wave. The positive traveling direction is x[0] and the vertical
-        coordinate is x[2] which is zero at the bottom and equal to +depth at
-        the mean water level.
-        """
-        N = len(self.eta) - 1
-        J = arange(1, N + 1)
-        k = self.k
-        c = self.c
-
-        Jk = J * k
-        facs = self.B / cosh(Jk * self.height)
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        z2 = np2py(self.depth_water + self.height)
-        c = np2py(self.c)
-        Jk  = np2py(Jk)
-        facs  = np2py(facs)
-
-        z2_cpp = f"({z2!r} - x[2])"
-        cpp = " + ".join(
-            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * {z2_cpp})"
-            for i in range(N)
-        )
-
-        if frame == "b":
-            B0 = np2py(self.c)
-            return f"{B0!r} * x[2] + {cpp}"
-        elif frame == "c":
-            return cpp
-
-    def velocity_cpp(self):
-        """
-        Return C++ code for evaluating the particle velocities of this specific
-        wave. Returns the x and z components only with z positive upwards. The
-        positive traveling direction is x[0] and the vertical coordinate is x[2]
-        which is zero at the bottom and equal to +depth at the mean water level.
-        """
-        N = len(self.eta) - 1
-        J = arange(1, N + 1)
-        k = self.k
-        c = self.c
-
-        Jk = J * k
-        facs = J * self.B * k / cosh(Jk * self.height)
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        z2 = np2py(self.depth_water + self.height)
-        c = np2py(self.c)
-        Jk  = np2py(Jk)
-        facs  = np2py(facs)
-
-        z2_cpp = f"({z2!r} - x[2])"
-        cpp_x = " + ".join(
-            f"{-facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * cosh({Jk[i]!r} * {z2_cpp})"
-            for i in range(N)
-        )
-        cpp_z = " + ".join(
-            f"{facs[i]!r} * sin({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * {z2_cpp})"
-            for i in range(N)
-        )
-        return (cpp_x, cpp_z)
 
     def __repr__(self):
         return ("FentonAirPhase(height={s.height}, blending_height=" "{s.blending_height})").format(

--- a/raschii/air_phase_fenton.py
+++ b/raschii/air_phase_fenton.py
@@ -1,9 +1,11 @@
-from numpy import zeros, asarray, arange, sin, cos, sinh, cosh, newaxis
+from numpy import arange, asarray, cos, cosh, newaxis, sin, sinh, zeros
 from numpy.linalg import solve
-from .common import sinh_by_cosh, AIR_BLENDING_HEIGHT_FACTOR, np2py
+
+from .base_classes import AirPhaseModel
+from .common import AIR_BLENDING_HEIGHT_FACTOR, Frame, sinh_by_cosh
 
 
-class FentonAirPhase:
+class FentonAirPhase(AirPhaseModel):
     def __init__(self, height, blending_height=None):
         """
         Given a set of colocation points with precomputed surface elevations
@@ -31,11 +33,16 @@ class FentonAirPhase:
             self.blending_height = AIR_BLENDING_HEIGHT_FACTOR * wave.height
 
         from .cpp import FentonAirCppGenerator
+
         self.cpp = FentonAirCppGenerator(self)
 
-    def stream_function(self, x, z, t=0, frame="b"):
+    def stream_function(self, x, z, t=0, frame=Frame.EARTH):
         """
-        Compute the stream function at time t for position(s) x
+        Compute the stream function at time t for position(s) x.
+
+        * frame: :class:`~raschii.Frame` – ``Frame.EARTH`` (default) includes
+          the constant base-flow term; ``Frame.WAVE`` returns only the
+          oscillatory part.
         """
         if isinstance(x, (float, int)):
             x, z = [x], [z]
@@ -51,10 +58,12 @@ class FentonAirPhase:
 
         psi = (sinh(J * k * z2) / cosh(J * k * self.height) * cos(J * k * x2)).dot(B)
 
-        if frame == "e":
+        if frame == Frame.EARTH:
             return B0 * z + psi
-        elif frame == "c":
+        elif frame == Frame.WAVE:
             return psi
+        else:
+            raise ValueError(f"Unknown frame {frame!r}; use Frame.EARTH or Frame.WAVE")
 
     def velocity(self, x, z, t=0):
         """
@@ -84,9 +93,7 @@ class FentonAirPhase:
         return vel
 
     def __repr__(self):
-        return ("FentonAirPhase(height={s.height}, blending_height=" "{s.blending_height})").format(
-            s=self
-        )
+        return f"FentonAirPhase(height={self.height}, blending_height={self.blending_height})"
 
 
 def air_velocity_coefficients(x, eta, c, k, depth_water, height_air):

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -3,7 +3,7 @@ from .common import (
     blend_air_and_wave_velocities,
     blend_air_and_wave_velocity_cpp,
     np2py,
-    RasciiError,
+    RaschiiError,
     NonConvergenceError,
 )
 from .base_classes import WaveModel
@@ -33,7 +33,7 @@ class AiryWave(WaveModel):
         """
         if length is None:
             if period is None:
-                raise RasciiError("Either length or period must be given, both are None!")
+                raise RaschiiError("Either length or period must be given, both are None!")
             length = compute_length_from_period(depth=depth, period=period, g=g)
 
         self.height: float = height  #: The wave height
@@ -70,7 +70,7 @@ class AiryWave(WaveModel):
 
         if include_depth:
             if self.depth < 0:
-                raise RasciiError("Cannot include depth in elevation for infinite depth")
+                raise RaschiiError("Cannot include depth in elevation for infinite depth")
             offset = self.depth
         else:
             offset = 0.0
@@ -89,7 +89,7 @@ class AiryWave(WaveModel):
         where z is 0 at the bottom and equal to depth at the free surface
         """
         if self.depth < 0:
-            raise RasciiError("Cannot currently compute velocity for infinite depth waves")
+            raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
         if isinstance(x, (float, int)):
             x, z = [x], [z]
         x = asarray(x, dtype=float)

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -1,8 +1,4 @@
 from numpy import (
-    array,
-    asarray,
-    atleast_1d,
-    broadcast_arrays,
     cos,
     cosh,
     newaxis,
@@ -75,85 +71,30 @@ class AiryWave(WaveModel):
         if self.air is not None:
             self.air.set_wave(self)
 
-    def surface_elevation(
-        self,
-        x: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        include_depth: bool = True,
-    ):
-        """
-        Compute the surface elavation at time t for position(s) x
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        x = atleast_1d(asarray(x, dtype=float))  # (N,)
-        t = atleast_1d(asarray(t, dtype=float))  # (T,)
-
+    def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         if include_depth:
             if self.depth < 0:
                 raise RaschiiError("Cannot include depth in elevation for infinite depth")
             offset = self.depth
         else:
             offset = 0.0
+        return offset + self.height / 2 * cos(self.k * x[newaxis, :] - self.omega * t[:, newaxis])
 
-        # result shape: (T, N)
-        result = offset + self.height / 2 * cos(self.k * x[newaxis, :] - self.omega * t[:, newaxis])
-
-        if t_was_scalar:
-            return result[0]  # (N,)
-        elif x_was_scalar:
-            return result[:, 0]  # (T,)
-        return result  # (T, N)
-
-    def velocity(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        all_points_wet: bool = False,
-    ):
-        """
-        Compute the fluid velocity at time t for position(s) (x, z)
-        where z is 0 at the bottom and equal to depth at the free surface
-        """
+    def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
-
-        time_is_scalar = asarray(t).ndim == 0
-        point_is_scalar = asarray(x).ndim == 0 and asarray(z).ndim == 0
-
-        x = atleast_1d(asarray(x, dtype=float))
-        z = atleast_1d(asarray(z, dtype=float))
-        t = atleast_1d(asarray(t, dtype=float))
-
-        x, z = broadcast_arrays(x, z)
-
-        x = x[newaxis, :]  # (1, n_points)
-        z = z[newaxis, :]  # (1, n_points)
-        t = t[:, newaxis]  # (n_times, 1)
-
         H = self.height
         k = self.k
         d = self.depth
         w = self.omega
-
-        phase = k * x - w * t  # (n_times, n_points)
-        vel_x = w * H / 2 * cosh(k * z) / sinh(k * d) * cos(phase)
-        vel_z = w * H / 2 * sinh(k * z) / sinh(k * d) * sin(phase)
-        vel = stack([vel_x, vel_z], axis=-1)  # (n_times, n_points, 2)
-
+        phase = k * x[newaxis, :] - w * t[:, newaxis]  # (T, N)
+        vel_x = w * H / 2 * cosh(k * z[newaxis, :]) / sinh(k * d) * cos(phase)
+        vel_z = w * H / 2 * sinh(k * z[newaxis, :]) / sinh(k * d) * sin(phase)
+        vel = stack([vel_x, vel_z], axis=-1)  # (T, N, 2)
         if not all_points_wet:
             # blend_air_and_wave_velocities needs updating for new shape convention
             pass
-
-        if time_is_scalar and point_is_scalar:
-            return vel.squeeze()  # (2,)
-        elif time_is_scalar:
-            return vel[0]  # (n_points, 2)
-        elif point_is_scalar:
-            return vel[:, 0]  # (n_times, 2)
-        return vel  # (n_times, n_points, 2)
+        return vel
 
     def elevation_cpp(self):
         """
@@ -234,56 +175,18 @@ class AiryWave(WaveModel):
 
         SwdWriterAiry(self).write(path, dt, tmax=tmax, nperiods=nperiods, amp=amp)
 
-    def velocity_potential(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-    ):
-        """
-        Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
-
-        z is measured from the sea floor (z=0 at bottom, z≈depth at calm surface).
-        The gradient ∇φ equals the oscillatory fluid velocity as returned by
-        :meth:`velocity`; the formula is
-
-        .. math::
-
-           \\phi(x, z, t) = \\frac{\\omega H}{2k}
-               \\frac{\\cosh(kz)}{\\sinh(kd)}\\sin(kx - \\omega t)
-
-        Works for both finite and infinite depth.  For infinite-depth waves
-        (``depth=-1``) an effective depth of 25 × wave_length is used internally;
-        z should be supplied in the same coordinate system (z=0 at the effective
-        sea floor).
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        if x_was_scalar:
-            x, z = [x], [z]
-        x = atleast_1d(asarray(x, dtype=float))  # (N,)
-        z = atleast_1d(asarray(z, dtype=float))  # (N,)
-        t = atleast_1d(asarray(t, dtype=float))  # (T,)
-
+    def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
         H = self.height
         k = self.k
         w = self.omega
         d = 25.0 * self.length if self.depth < 0 else self.depth
-
-        # result shape: (T, N)
-        result = (
-            (w * H) / (2 * k)
+        return (
+            (w * H)
+            / (2 * k)
             * cosh_ratio(k * z[newaxis, :], k * d)
             / tanh(k * d)
             * sin(k * x[newaxis, :] - w * t[:, newaxis])
         )
-
-        if t_was_scalar:
-            return result[0]  # (N,)
-        elif x_was_scalar:
-            return result[:, 0]  # (T,)
-        return result  # (T, N)
 
 
 def compute_length_from_period(depth: float, period: float, g: float = 9.81) -> float:

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -15,9 +15,7 @@ from .base_classes import WaveModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
-    blend_air_and_wave_velocity_cpp,
     cosh_ratio,
-    np2py,
 )
 
 

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -21,7 +21,7 @@ from .cpp import AiryCppGenerator
 
 
 class AiryWave(WaveModel):
-    required_input = ("height", "depth", "length")
+    required_input = {"height", "depth", "length"}
     optional_input = {"air": None, "g": 9.81}
 
     def __init__(
@@ -29,6 +29,7 @@ class AiryWave(WaveModel):
         height: float,
         depth: float,
         length: float | None = None,
+        *,
         period: float | None = None,
         air=None,
         g: float = 9.81,

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -9,6 +9,7 @@ from numpy import (
     tanh,
 )
 from numpy.typing import NDArray
+from .cpp import AiryCppGenerator
 
 from .base_classes import WaveModel
 from .common import (
@@ -71,6 +72,8 @@ class AiryWave(WaveModel):
         if self.air is not None:
             self.air.set_wave(self)
 
+        self.cpp = AiryCppGenerator(self)
+
     def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         if include_depth:
             if self.depth < 0:
@@ -95,60 +98,6 @@ class AiryWave(WaveModel):
             # blend_air_and_wave_velocities needs updating for new shape convention
             pass
         return vel
-
-    def elevation_cpp(self):
-        """
-        Return C++ code for evaluating the elevation of this specific wave.
-        The positive traveling direction is x[0]
-        """
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        depth = np2py(self.depth)
-        height = np2py(self.height)
-        k = np2py(self.k)
-        c = np2py(self.c)
-
-        return f"{depth!r} + {height!r} / 2.0 * cos({k!r} * (x[0] - {c!r} * t))"
-
-    def velocity_cpp(self, all_points_wet=False):
-        """
-        Return C++ code for evaluating the particle velocities of this specific
-        wave. Returns the x and z components only with z positive upwards. The
-        positive traveling direction is x[0] and the vertical coordinate is x[2]
-        which is zero at the bottom and equal to +depth at the mean water level.
-        """
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        H = float(self.height)
-        k = float(self.k)
-        d = float(self.depth)
-        w = float(self.omega)
-        a = float(w * H / (2 * sinh(k * d)))
-
-        cpp_x = f"{a!r} * cosh({k!r} * x[2]) * cos({k!r} * x[0] - {w!r} * t)"
-        cpp_z = f"{a!r} * sinh({k!r} * x[2]) * sin({k!r} * x[0] - {w!r} * t)"
-
-        if all_points_wet:
-            return cpp_x, cpp_z
-
-        # Handle velocities above the free surface
-        e_cpp = self.elevation_cpp()
-        cpp_ax = cpp_az = None
-        cpp_psiw = cpp_psia = cpp_slope = None
-        if self.air is not None:
-            cpp_ax, cpp_az = self.air.velocity_cpp()
-            cpp_psiw = self.stream_function_cpp(frame="c")
-            cpp_psia = self.air.stream_function_cpp(frame="c")
-            cpp_slope = self.slope_cpp()
-
-        cpp_x = blend_air_and_wave_velocity_cpp(
-            cpp_x, cpp_ax, e_cpp, "x", self.eta_eps, self.air, cpp_psiw, cpp_psia, cpp_slope
-        )
-        cpp_z = blend_air_and_wave_velocity_cpp(
-            cpp_z, cpp_az, e_cpp, "z", self.eta_eps, self.air, cpp_psiw, cpp_psia, cpp_slope
-        )
-
-        return cpp_x, cpp_z
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -10,7 +10,7 @@ from numpy import (
 )
 from numpy.typing import NDArray
 
-from .base_classes import WaveModel
+from .base_classes import WaveModel, AirPhaseModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
@@ -31,7 +31,7 @@ class AiryWave(WaveModel):
         length: float | None = None,
         *,
         period: float | None = None,
-        air=None,
+        air: AirPhaseModel | None = None,
         g: float = 9.81,
     ):
         """
@@ -48,11 +48,21 @@ class AiryWave(WaveModel):
                 raise RaschiiError("Either length or period must be given, both are None!")
             length = compute_length_from_period(depth=depth, period=period, g=g)
 
-        self.height: float = height  #: The wave height
-        self.depth: float = depth  #: The water depth
-        self.length: float = length  #: The wave length
-        self.air = air  #: The optional air-phase model
-        self.g: float = g  #: The acceleration of gravity
+        #: The wave height
+        self.height: float = height
+
+        #: The water depth
+        self.depth: float = depth
+
+        #: The wave length
+        self.length: float = length
+
+        #: The optional air-phase model
+        self.air: AirPhaseModel | None = air
+
+        #: The acceleration of gravity
+        self.g: float = g
+
         self.warnings: str = ""  #: Warnings raised when generating this wave
 
         self.k = 2 * pi / length

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -1,13 +1,27 @@
-from numpy import pi, cos, sin, zeros, array, asarray, sinh, cosh, tanh
+from numpy import (
+    array,
+    asarray,
+    atleast_1d,
+    broadcast_arrays,
+    cos,
+    cosh,
+    newaxis,
+    pi,
+    sin,
+    sinh,
+    stack,
+    tanh,
+)
+from numpy.typing import NDArray
+
+from .base_classes import WaveModel
 from .common import (
-    blend_air_and_wave_velocities,
+    NonConvergenceError,
+    RaschiiError,
     blend_air_and_wave_velocity_cpp,
     cosh_ratio,
     np2py,
-    RaschiiError,
-    NonConvergenceError,
 )
-from .base_classes import WaveModel
 
 
 class AiryWave(WaveModel):
@@ -61,13 +75,20 @@ class AiryWave(WaveModel):
         if self.air is not None:
             self.air.set_wave(self)
 
-    def surface_elevation(self, x: float | list[float], t: float = 0.0, include_depth: bool = True):
+    def surface_elevation(
+        self,
+        x: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
+        include_depth: bool = True,
+    ):
         """
         Compute the surface elavation at time t for position(s) x
         """
-        if isinstance(x, (float, int)):
-            x = array([x], float)
-        x = asarray(x)
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
+
+        x = atleast_1d(asarray(x, dtype=float))  # (N,)
+        t = atleast_1d(asarray(t, dtype=float))  # (T,)
 
         if include_depth:
             if self.depth < 0:
@@ -76,13 +97,20 @@ class AiryWave(WaveModel):
         else:
             offset = 0.0
 
-        return offset + self.height / 2 * cos(self.k * x - self.omega * t)
+        # result shape: (T, N)
+        result = offset + self.height / 2 * cos(self.k * x[newaxis, :] - self.omega * t[:, newaxis])
+
+        if t_was_scalar:
+            return result[0]  # (N,)
+        elif x_was_scalar:
+            return result[:, 0]  # (T,)
+        return result  # (T, N)
 
     def velocity(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
         all_points_wet: bool = False,
     ):
         """
@@ -91,24 +119,41 @@ class AiryWave(WaveModel):
         """
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
-        if isinstance(x, (float, int)):
-            x, z = [x], [z]
-        x = asarray(x, dtype=float)
-        z = asarray(z, dtype=float)
+
+        time_is_scalar = asarray(t).ndim == 0
+        point_is_scalar = asarray(x).ndim == 0 and asarray(z).ndim == 0
+
+        x = atleast_1d(asarray(x, dtype=float))
+        z = atleast_1d(asarray(z, dtype=float))
+        t = atleast_1d(asarray(t, dtype=float))
+
+        x, z = broadcast_arrays(x, z)
+
+        x = x[newaxis, :]  # (1, n_points)
+        z = z[newaxis, :]  # (1, n_points)
+        t = t[:, newaxis]  # (n_times, 1)
 
         H = self.height
         k = self.k
         d = self.depth
         w = self.omega
 
-        vel = zeros((x.size, 2), float) + 1
-        vel[:, 0] = w * H / 2 * cosh(k * z) / sinh(k * d) * cos(k * x - w * t)
-        vel[:, 1] = w * H / 2 * sinh(k * z) / sinh(k * d) * sin(k * x - w * t)
+        phase = k * x - w * t  # (n_times, n_points)
+        vel_x = w * H / 2 * cosh(k * z) / sinh(k * d) * cos(phase)
+        vel_z = w * H / 2 * sinh(k * z) / sinh(k * d) * sin(phase)
+        vel = stack([vel_x, vel_z], axis=-1)  # (n_times, n_points, 2)
 
         if not all_points_wet:
-            blend_air_and_wave_velocities(x, z, t, self, self.air, vel, self.eta_eps)
+            # blend_air_and_wave_velocities needs updating for new shape convention
+            pass
 
-        return vel
+        if time_is_scalar and point_is_scalar:
+            return vel.squeeze()  # (2,)
+        elif time_is_scalar:
+            return vel[0]  # (n_points, 2)
+        elif point_is_scalar:
+            return vel[:, 0]  # (n_times, 2)
+        return vel  # (n_times, n_points, 2)
 
     def elevation_cpp(self):
         """
@@ -191,9 +236,9 @@ class AiryWave(WaveModel):
 
     def velocity_potential(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
     ):
         """
         Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
@@ -212,21 +257,33 @@ class AiryWave(WaveModel):
         z should be supplied in the same coordinate system (z=0 at the effective
         sea floor).
         """
-        if isinstance(x, (float, int)):
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
+
+        if x_was_scalar:
             x, z = [x], [z]
-        x = asarray(x, dtype=float)
-        z = asarray(z, dtype=float)
+        x = atleast_1d(asarray(x, dtype=float))  # (N,)
+        z = atleast_1d(asarray(z, dtype=float))  # (N,)
+        t = atleast_1d(asarray(t, dtype=float))  # (T,)
 
         H = self.height
         k = self.k
         w = self.omega
-
         d = 25.0 * self.length if self.depth < 0 else self.depth
 
-        # phi = (w H) / (2 k) * cosh(kz) / sinh(kd) * sin(kx - wt)
-        #     = (w H) / (2 k) * cosh_ratio(kz, kd) / tanh(kd) * sin(kx - wt)
-        # tanh(kd) -> 1 for deep water and never overflows.
-        return (w * H) / (2 * k) * cosh_ratio(k * z, k * d) / tanh(k * d) * sin(k * x - w * t)
+        # result shape: (T, N)
+        result = (
+            (w * H) / (2 * k)
+            * cosh_ratio(k * z[newaxis, :], k * d)
+            / tanh(k * d)
+            * sin(k * x[newaxis, :] - w * t[:, newaxis])
+        )
+
+        if t_was_scalar:
+            return result[0]  # (N,)
+        elif x_was_scalar:
+            return result[:, 0]  # (T,)
+        return result  # (T, N)
 
 
 def compute_length_from_period(depth: float, period: float, g: float = 9.81) -> float:

--- a/raschii/airy.py
+++ b/raschii/airy.py
@@ -9,14 +9,15 @@ from numpy import (
     tanh,
 )
 from numpy.typing import NDArray
-from .cpp import AiryCppGenerator
 
 from .base_classes import WaveModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
+    blend_air_and_wave_velocities,
     cosh_ratio,
 )
+from .cpp import AiryCppGenerator
 
 
 class AiryWave(WaveModel):
@@ -84,6 +85,7 @@ class AiryWave(WaveModel):
     def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
+        x_1d, z_1d, t_1d = x, z, t  # save (N,), (N,), (T,) before reshaping
         H = self.height
         k = self.k
         d = self.depth
@@ -93,8 +95,10 @@ class AiryWave(WaveModel):
         vel_z = w * H / 2 * sinh(k * z[newaxis, :]) / sinh(k * d) * sin(phase)
         vel = stack([vel_x, vel_z], axis=-1)  # (T, N, 2)
         if not all_points_wet:
-            # blend_air_and_wave_velocities needs updating for new shape convention
-            pass
+            for i, ti in enumerate(t_1d):
+                blend_air_and_wave_velocities(
+                    x_1d, z_1d, float(ti), self, self.air, vel[i], self.eta_eps
+                )
         return vel
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):

--- a/raschii/base_classes.py
+++ b/raschii/base_classes.py
@@ -1,3 +1,6 @@
+from numpy.typing import NDArray
+
+
 class WaveModel:
     """
     Base class for Raschii wave models.
@@ -14,17 +17,22 @@ class WaveModel:
         self.k: float  #: The wave number [1/m], to be defined in subclasses
         self.c: float  #: The wave celery [m/s], to be defined in subclasses
 
-    def surface_elevation(self, x: float | list[float], t: float = 0.0, include_depth: bool = True):
+    def surface_elevation(
+        self,
+        x: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
+        include_depth: bool = True,
+    ):
         """
-        Compute the surface elavation at time t for position(s) x
+        Compute the surface elevation at time t for position(s) x
         """
         raise NotImplementedError("This method should be implemented in subclasses.")
 
     def velocity(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
         all_points_wet: bool = False,
     ):
         """
@@ -35,9 +43,9 @@ class WaveModel:
 
     def velocity_potential(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
     ):
         """
         Compute the earth-frame velocity potential φ at time t for position(s) (x, z).

--- a/raschii/base_classes.py
+++ b/raschii/base_classes.py
@@ -28,8 +28,8 @@ class WaveModel:
         #: The acceleration of gravity
         self.g: float = g
 
-        #: The wave period [t], to be defined in subclasses
-        self.T: float
+        #: The wave period [s], to be defined in subclasses
+        self.period: float
 
         #: The wave angular frequency [rad/s], to be defined in subclasses
         self.omega: float

--- a/raschii/base_classes.py
+++ b/raschii/base_classes.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
 import numpy as np
 from numpy.typing import NDArray
+
+from .common import Frame
+from .cpp import WaveModelCppGenerator
 
 
 class WaveModel:
@@ -8,15 +13,35 @@ class WaveModel:
     """
 
     def __init__(self, height: float, depth: float, length: float, g: float = 9.81):
-        self.height: float = height  #: The wave height
-        self.depth: float = depth  #: The water depth
-        self.length: float = length  #: The wave length
-        self.g: float = g  #: The acceleration of gravity
+        """
+        The Raschii base wave model.
+        """
+        #: The wave height
+        self.height: float = height
 
-        self.T: float  #: The wave period [t], to be defined in subclasses
-        self.omega: float  #: The wave angular frequency [rad/s], to be defined in subclasses
-        self.k: float  #: The wave number [1/m], to be defined in subclasses
-        self.c: float  #: The wave celerity [m/s], to be defined in subclasses
+        #: The water depth
+        self.depth: float = depth
+
+        #: The wave length
+        self.length: float = length
+
+        #: The acceleration of gravity
+        self.g: float = g
+
+        #: The wave period [t], to be defined in subclasses
+        self.T: float
+
+        #: The wave angular frequency [rad/s], to be defined in subclasses
+        self.omega: float
+
+        #: The wave number [1/m], to be defined in subclasses
+        self.k: float
+
+        #: The wave celerity [m/s], to be defined in subclasses
+        self.c: float
+
+        #: The C++ code generator for this wave model, to be defined in subclasses
+        self.cpp: WaveModelCppGenerator | None = None
 
     def surface_elevation(
         self,
@@ -127,4 +152,45 @@ class WaveModel:
 
     def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
         """Compute velocity potential. x, z: (N,), t: (T,) → returns (T, N)."""
+        raise NotImplementedError("This method should be implemented in subclasses.")
+
+
+class AirPhaseModel:
+    def __init__(self, height: float, blending_height: float | None = None):
+        """
+        The Raschii base air-phase model.
+
+        Divergence free kinematics also above the free surface
+        """
+        self.height: float = height
+        self.blending_height: float | None = blending_height
+
+        from .cpp import AirPhaseModelCppGenerator
+
+        self.cpp: AirPhaseModelCppGenerator
+
+    def set_wave(self, wave: WaveModel):
+        """
+        Connect this air phase with the wave in the water phase
+        """
+        raise NotImplementedError("This method should be implemented in subclasses.")
+
+    def stream_function(self, x, z, t=0, frame=Frame.EARTH):
+        """
+        Compute the stream function at time t for position(s) x.
+
+        * frame: :class:`~raschii.Frame` – ``Frame.EARTH`` (default) returns
+          zero (still air in the earth frame); ``Frame.WAVE`` returns ``-c*z``
+          (air appears to move backward at the wave phase speed in the
+          co-moving frame).
+        """
+        raise NotImplementedError("This method should be implemented in subclasses.")
+
+    def velocity(self, x, z, t=0):
+        """
+        Compute the air phase particle velocity at time t for position(s) (x, z)
+        where z is 0 at the bottom and equal to depth_water at the free surface
+        and equal to depth_water + depth air at the top free slip lid above the
+        air phase
+        """
         raise NotImplementedError("This method should be implemented in subclasses.")

--- a/raschii/base_classes.py
+++ b/raschii/base_classes.py
@@ -1,3 +1,4 @@
+import numpy as np
 from numpy.typing import NDArray
 
 
@@ -15,18 +16,37 @@ class WaveModel:
         self.T: float  #: The wave period [t], to be defined in subclasses
         self.omega: float  #: The wave angular frequency [rad/s], to be defined in subclasses
         self.k: float  #: The wave number [1/m], to be defined in subclasses
-        self.c: float  #: The wave celery [m/s], to be defined in subclasses
+        self.c: float  #: The wave celerity [m/s], to be defined in subclasses
 
     def surface_elevation(
         self,
         x: float | list[float] | NDArray,
         t: float | list[float] | NDArray = 0.0,
         include_depth: bool = True,
-    ):
+    ) -> NDArray | float:
         """
-        Compute the surface elevation at time t for position(s) x
+        Compute the surface elevation at time t for position(s) x.
+
+        Returns a scalar when both x and t are scalar, an ndarray otherwise.
+        Output shape follows the NumPy convention (scalar in → scalar out):
+
+        - scalar x, scalar t  → scalar
+        - array x (N), scalar t → (N,)
+        - scalar x, array t (T) → (T,)
+        - array x (N), array t (T) → (T, N)
         """
-        raise NotImplementedError("This method should be implemented in subclasses.")
+        x_was_scalar = np.asarray(x).ndim == 0
+        t_was_scalar = np.asarray(t).ndim == 0
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        t_arr = np.atleast_1d(np.asarray(t, dtype=float))
+        result = self._surface_elevation(x_arr, t_arr, include_depth)  # (T, N)
+        if x_was_scalar and t_was_scalar:
+            return result[0, 0]
+        elif t_was_scalar:
+            return result[0]
+        elif x_was_scalar:
+            return result[:, 0]
+        return result
 
     def velocity(
         self,
@@ -34,19 +54,39 @@ class WaveModel:
         z: float | list[float] | NDArray,
         t: float | list[float] | NDArray = 0.0,
         all_points_wet: bool = False,
-    ):
+    ) -> NDArray:
         """
         Compute the fluid velocity at time t for position(s) (x, z)
-        where z is 0 at the bottom and equal to depth at the free surface
+        where z is 0 at the bottom and equal to depth at the free surface.
+
+        Output shape:
+
+        - (2,) if x, z, and t are scalar
+        - (N, 2) if x/z are arrays and t is scalar
+        - (T, 2) if x/z are scalar and t is an array
+        - (T, N, 2) if x/z are arrays and t is an array
         """
-        raise NotImplementedError("This method should be implemented in subclasses.")
+        point_is_scalar = np.asarray(x).ndim == 0 and np.asarray(z).ndim == 0
+        time_is_scalar = np.asarray(t).ndim == 0
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        z_arr = np.atleast_1d(np.asarray(z, dtype=float))
+        t_arr = np.atleast_1d(np.asarray(t, dtype=float))
+        x_arr, z_arr = np.broadcast_arrays(x_arr, z_arr)
+        result = self._velocity(x_arr, z_arr, t_arr, all_points_wet)  # (T, N, 2)
+        if time_is_scalar and point_is_scalar:
+            return result.squeeze()
+        elif time_is_scalar:
+            return result[0]
+        elif point_is_scalar:
+            return result[:, 0]
+        return result
 
     def velocity_potential(
         self,
         x: float | list[float] | NDArray,
         z: float | list[float] | NDArray,
         t: float | list[float] | NDArray = 0.0,
-    ):
+    ) -> NDArray | float:
         """
         Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
 
@@ -54,9 +94,37 @@ class WaveModel:
         The gradient of φ equals the oscillatory fluid velocity as returned by
         :meth:`velocity`; the mean-flow current term is excluded.
 
-        Works for both finite and infinite depth.  For infinite-depth waves
-        (``depth=-1``) an effective depth of 25 × wave_length is used internally;
-        z should be supplied in the same coordinate system (z=0 at the effective
-        sea floor).
+        Returns a scalar when both x/z and t are scalar, an ndarray otherwise.
+        Output shape:
+
+        - scalar x/z, scalar t → scalar
+        - array x/z (N), scalar t → (N,)
+        - scalar x/z, array t (T) → (T,)
+        - array x/z (N), array t (T) → (T, N)
         """
+        point_is_scalar = np.asarray(x).ndim == 0 and np.asarray(z).ndim == 0
+        t_was_scalar = np.asarray(t).ndim == 0
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        z_arr = np.atleast_1d(np.asarray(z, dtype=float))
+        t_arr = np.atleast_1d(np.asarray(t, dtype=float))
+        x_arr, z_arr = np.broadcast_arrays(x_arr, z_arr)
+        result = self._velocity_potential(x_arr, z_arr, t_arr)  # (T, N)
+        if point_is_scalar and t_was_scalar:
+            return result[0, 0]
+        elif t_was_scalar:
+            return result[0]
+        elif point_is_scalar:
+            return result[:, 0]
+        return result
+
+    def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
+        """Compute surface elevation. x: (N,), t: (T,) → returns (T, N)."""
+        raise NotImplementedError("This method should be implemented in subclasses.")
+
+    def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
+        """Compute fluid velocity. x, z: (N,), t: (T,) → returns (T, N, 2)."""
+        raise NotImplementedError("This method should be implemented in subclasses.")
+
+    def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
+        """Compute velocity potential. x, z: (N,), t: (T,) → returns (T, N)."""
         raise NotImplementedError("This method should be implemented in subclasses.")

--- a/raschii/cmd/plot.py
+++ b/raschii/cmd/plot.py
@@ -10,11 +10,12 @@ def plot_wave(
     model_names,
     height,
     depth,
-    length,
-    N,
-    depth_air,
-    blend_height,
-    t,
+    length=None,
+    period=None,
+    N=10,
+    depth_air=0.0,
+    blend_height=-1,
+    t=0.0,
     Nx=21,
     Ny=21,
     plot_quiver=False,
@@ -44,8 +45,17 @@ def plot_wave(
 
     # Vertical axis limits
     ymin_user, ymax_user = ymin, ymax
+    # Use an Airy deep-water estimate when only the period is known so we can
+    # set reasonable plot limits before the wave objects are constructed.
+    if length is None:
+        if period is None:
+            raise ValueError("Either length or period must be given")
+        from math import pi as _pi
+        _length_est = 9.81 * period**2 / (2 * _pi)
+    else:
+        _length_est = length
     ymax = depth + height * 1.5
-    ymin = max(depth - length * 2, 0)  # Include only 2 wave lengths dept,
+    ymin = max(depth - _length_est * 2, 0)  # Include only 2 wave lengths depth,
     ymin = max(depth - height * 10, ymin)  # but no more than 10 wave heights
 
     # Horizontal velocity axis limits
@@ -54,7 +64,7 @@ def plot_wave(
 
     # Increase upper vertical limit if plotting the air phase
     if depth_air > 0:
-        ymax = min(depth + length * 2, depth + depth_air)
+        ymax = min(depth + _length_est * 2, depth + depth_air)
         ymax = min(depth + height * 10, ymax)
 
     # Let the user override the axis limits
@@ -65,7 +75,11 @@ def plot_wave(
     warnings = ""
     for model_name in model_names:
         WaveClass, AirClass = get_wave_model(model_name)
-        args = dict(height=height, depth=depth, length=length)
+        args: dict = dict(height=height, depth=depth)
+        if length is not None:
+            args["length"] = length
+        else:
+            args["period"] = period
         if "N" in WaveClass.required_input:
             args["N"] = N
 
@@ -74,12 +88,12 @@ def plot_wave(
             args["air"] = AirClass(depth_air, blend_height)
 
         wave = WaveClass(**args)
+        length = wave.length  # update from actual wave (important when period was given)
         plot_air = wave.air is not None
         if wave.warnings:
             warnings += "WARNINGS for %s:\n%s" % (model_name, wave.warnings)
 
         # Get elevation
-        assert length > 0
         x = numpy.linspace(-length / 2, length / 2, 200)
         eta = wave.surface_elevation(x, t)
 
@@ -145,7 +159,7 @@ def plot_wave(
         # Plot the velocities in vertical slices
         for i, ax in enumerate(ax2s):
             xi = length / 2 * i / 4
-            e = wave.surface_elevation(xi, t)[0]
+            e = wave.surface_elevation(xi, t)
             y = numpy.linspace(ymin, e, 1000)
             v = wave.velocity(y * 0 + xi, y, t)
             if i < 5:
@@ -167,8 +181,8 @@ def plot_wave(
 
         # Crest and trough velocities
         eta0 = wave.surface_elevation([0.0, length / 2], t=0)
-        u_crest = wave.velocity(0.0, eta0[0], t=0)[0, 0]
-        u_trough = wave.velocity(length / 2, eta0[1], t=0)[0, 0]
+        u_crest = wave.velocity(0.0, eta0[0], t=0)[0]
+        u_trough = wave.velocity(length / 2, eta0[1], t=0)[0]
 
         # Print some info
         print(
@@ -245,7 +259,20 @@ def main() -> int:
     )
     parser.add_argument("wave_height", help="Wave height", type=float)
     parser.add_argument("water_depth", help="The still water depth", type=float)
-    parser.add_argument("wave_length", help="Distance between peaks", type=float)
+    parser.add_argument(
+        "wave_length",
+        nargs="?",
+        default=None,
+        type=float,
+        help="Distance between wave crests. Mutually exclusive with --period / -T.",
+    )
+    parser.add_argument(
+        "-T",
+        "--period",
+        type=float,
+        default=None,
+        help="Wave period in seconds (alternative to the positional wave_length argument).",
+    )
     parser.add_argument("-N", type=int, default=10, help="Approximation order")
     parser.add_argument(
         "-f",
@@ -278,7 +305,14 @@ def main() -> int:
     parser.add_argument("--ymax", default=None, type=float, help="Upper vertical axis limit")
     args = parser.parse_args()
 
-    err, warn = check_breaking_criteria(args.wave_height, args.water_depth, args.wave_length)
+    if args.wave_length is None and args.period is None:
+        parser.error("Either the positional wave_length or --period / -T must be given.")
+    if args.wave_length is not None and args.period is not None:
+        parser.error("wave_length and --period are mutually exclusive.")
+
+    err, warn = check_breaking_criteria(
+        args.wave_height, args.water_depth, length=args.wave_length, period=args.period
+    )
     if err:
         print(err)
     if warn:
@@ -292,6 +326,7 @@ def main() -> int:
         height=args.wave_height,
         depth=args.water_depth,
         length=args.wave_length,
+        period=args.period,
         N=args.N,
         depth_air=args.depth_air,
         blend_height=args.blend_height,

--- a/raschii/cmd/plot.py
+++ b/raschii/cmd/plot.py
@@ -21,14 +21,25 @@ def plot_wave(
     plot_quiver=False,
     ymin=None,
     ymax=None,
+    output_prefix=None,
 ) -> int:
     """
-    Plot waves with the given parameters
+    Plot waves with the given parameters.
+
+    If *output_prefix* is given the two figures are saved as
+    ``{output_prefix}_elevation.png`` and ``{output_prefix}_velocities.png``
+    and no interactive window is opened.  This is useful for headless
+    environments (CI, servers, etc.).
     """
     try:
+        import matplotlib
+
+        if output_prefix is not None:
+            # Non-interactive backend — must be set before pyplot is imported.
+            matplotlib.use("Agg")
         from matplotlib import pyplot
     except ImportError:
-        print("You need to install matplotlib to plot waves")
+        print("You need to install matplotlib to plot waves (pip install raschii[plot])")
         return 10
 
     # Figure for plot of wave with quiver
@@ -51,6 +62,7 @@ def plot_wave(
         if period is None:
             raise ValueError("Either length or period must be given")
         from math import pi as _pi
+
         _length_est = 9.81 * period**2 / (2 * _pi)
     else:
         _length_est = length
@@ -230,7 +242,15 @@ def plot_wave(
 
     fig1.tight_layout()
     fig2.tight_layout(rect=[0, 0.0, 1, 0.95])
-    pyplot.show()
+    if output_prefix is not None:
+        elev_path = f"{output_prefix}_elevation.png"
+        vel_path = f"{output_prefix}_velocities.png"
+        fig1.savefig(elev_path, dpi=150, bbox_inches="tight")
+        fig2.savefig(vel_path, dpi=150, bbox_inches="tight")
+        pyplot.close("all")
+        print(f"Saved {elev_path} and {vel_path}")
+    else:
+        pyplot.show()
     return 0
 
 
@@ -303,6 +323,16 @@ def main() -> int:
     parser.add_argument("-t", "--time", default=0.0, type=float, help="The time instance to plot")
     parser.add_argument("--ymin", default=None, type=float, help="Lower vertical axis limit")
     parser.add_argument("--ymax", default=None, type=float, help="Upper vertical axis limit")
+    parser.add_argument(
+        "-o",
+        "--output-prefix",
+        default=None,
+        metavar="PREFIX",
+        help=(
+            "Save figures to PNG files instead of opening an interactive window. "
+            "Two files are written: PREFIX_elevation.png and PREFIX_velocities.png."
+        ),
+    )
     args = parser.parse_args()
 
     if args.wave_length is None and args.period is None:
@@ -334,6 +364,7 @@ def main() -> int:
         plot_quiver=args.velocities,
         ymin=args.ymin,
         ymax=args.ymax,
+        output_prefix=args.output_prefix,
     )
 
 

--- a/raschii/cmd/swd.py
+++ b/raschii/cmd/swd.py
@@ -1,12 +1,22 @@
 from raschii import get_wave_model, check_breaking_criteria
 
 
-def write_swd(swd_file_name, model_name, height, depth, length, N, dt, tmax, amp=1):
+def write_swd(swd_file_name, model_name, height, depth, length, N, dt, tmax, amp=1, period=None):
     """
-    Write an SWD file for the wave with the given parameters
+    Write an SWD file for the wave with the given parameters.
+
+    Either *length* or *period* must be provided.  Pass ``length=None`` together
+    with a ``period`` value to specify the wave by its period instead.
     """
     WaveClass, _AirClass = get_wave_model(model_name)
-    args = dict(height=height, depth=depth, length=length)
+    args: dict = dict(height=height, depth=depth)
+    if length is not None:
+        args["length"] = length
+    elif period is not None:
+        args["period"] = period
+    else:
+        from raschii import RaschiiError
+        raise RaschiiError("Either length or period must be given")
     if "N" in WaveClass.required_input:
         args["N"] = N
     wave = WaveClass(**args)
@@ -29,11 +39,35 @@ def main():
     parser.add_argument("wave_type", help="Name of the wave model.")
     parser.add_argument("wave_height", help="Wave height", type=float)
     parser.add_argument("water_depth", help="The still water depth", type=float)
-    parser.add_argument("wave_length", help="Distance between peaks", type=float)
+    parser.add_argument(
+        "wave_length",
+        nargs="?",
+        default=None,
+        type=float,
+        help="Distance between wave crests. Mutually exclusive with --period / -T.",
+    )
+    parser.add_argument(
+        "-T",
+        "--period",
+        type=float,
+        default=None,
+        help="Wave period in seconds (alternative to the positional wave_length argument).",
+    )
     parser.add_argument("-N", type=int, default=10, help="Approximation order")
     parser.add_argument("--dt", type=float, default=0.01, help="Timestep")
     parser.add_argument("--tmax", type=float, default=10.0, help="Duration")
-    parser.add_argument("--swd-amp", type=int, default=1, help="SWD amp flag. Should be 1, 2, or 3")
+    parser.add_argument(
+        "--swd-amp",
+        type=int,
+        choices=[1, 2, 3],
+        default=1,
+        help=(
+            "SWD amp flag. "
+            "1 (default): store potential at z=0 (calm surface); "
+            "2: store potential on the wavy free surface; "
+            "3: store elevation only (no potential)."
+        ),
+    )
     parser.add_argument(
         "-f",
         "--force",
@@ -43,7 +77,14 @@ def main():
     )
     args = parser.parse_args()
 
-    err, warn = check_breaking_criteria(args.wave_height, args.water_depth, args.wave_length)
+    if args.wave_length is None and args.period is None:
+        parser.error("Either the positional wave_length or --period / -T must be given.")
+    if args.wave_length is not None and args.period is not None:
+        parser.error("wave_length and --period are mutually exclusive.")
+
+    err, warn = check_breaking_criteria(
+        args.wave_height, args.water_depth, length=args.wave_length, period=args.period
+    )
     if err:
         print(err)
     if warn:
@@ -57,6 +98,7 @@ def main():
         height=args.wave_height,
         depth=args.water_depth,
         length=args.wave_length,
+        period=args.period,
         N=args.N,
         dt=args.dt,
         tmax=args.tmax,

--- a/raschii/common.py
+++ b/raschii/common.py
@@ -8,11 +8,11 @@ import numpy as np
 AIR_BLENDING_HEIGHT_FACTOR = 2
 
 
-class RasciiError(Exception):
+class RaschiiError(Exception):
     pass
 
 
-class NonConvergenceError(RasciiError):
+class NonConvergenceError(RaschiiError):
     pass
 
 
@@ -33,7 +33,7 @@ def check_breaking_criteria(
     """
     if length is None:
         if period is None:
-            raise RasciiError("Either length or period must be given")
+            raise RaschiiError("Either length or period must be given")
 
         # We do not know the wave model, so we assume it is Airy
         # which should give a ballpark OK-ish answer

--- a/raschii/common.py
+++ b/raschii/common.py
@@ -54,7 +54,7 @@ def check_breaking_criteria(
 
         # We do not know the wave model, so we assume it is Airy
         # which should give a ballpark OK-ish answer
-        from .airy import compute_length_from_period
+        from .wave_airy import compute_length_from_period
 
         length = compute_length_from_period(depth=depth, period=period)
 

--- a/raschii/common.py
+++ b/raschii/common.py
@@ -1,7 +1,8 @@
 import math
+from enum import StrEnum
 from math import pi, tanh
-import numpy as np
 
+import numpy as np
 
 # If the air phase blending_height is None then the wave height times this
 # default factor will be used
@@ -14,6 +15,22 @@ class RaschiiError(Exception):
 
 class NonConvergenceError(RaschiiError):
     pass
+
+
+class Frame(StrEnum):
+    """
+    Reference frame
+
+    Currently only used for stream-function evaluations.
+    """
+
+    #: EARTH: earth/lab frame (stationary observer).
+    #: This includes the constant base-flow term.
+    EARTH = "EARTH"
+
+    #: WAVE: wave/co-moving frame (observer travelling with the wave crest).
+    #: The constant base-flow term is excluded.
+    WAVE = "WAVE"
 
 
 def check_breaking_criteria(
@@ -40,7 +57,7 @@ def check_breaking_criteria(
         from .airy import compute_length_from_period
 
         length = compute_length_from_period(depth=depth, period=period)
-    
+
     if depth < 0.0:
         # Use a large depth for infinite depth waves, same as is used
         # in the stokes_coefficients and fenton_coefficients functions
@@ -157,8 +174,8 @@ def blend_air_and_wave_velocities(x, z, t, wave, air, vel, eta_eps):
             eb = ea[blend]
             Z = (zb - eb) / (d - eb)
             vel_water = vel[above]
-            psi_wave = wave.stream_function(xb, zb, t, frame="c")
-            psi_air = air.stream_function(xb, zb, t, frame="c")
+            psi_wave = wave.stream_function(xb, zb, t, frame=Frame.WAVE)
+            psi_air = air.stream_function(xb, zb, t, frame=Frame.WAVE)
             detadx = wave.surface_slope(xb, t)
 
             if False:

--- a/raschii/cpp/__init__.py
+++ b/raschii/cpp/__init__.py
@@ -1,12 +1,8 @@
+from typing import TypeAlias
 from .cpp_airy import AiryCppGenerator
 from .cpp_fenton import FentonCppGenerator
 from .cpp_stokes import StokesCppGenerator
 from .cpp_air import ConstantAirCppGenerator, FentonAirCppGenerator
 
-__all__ = [
-    "AiryCppGenerator",
-    "FentonCppGenerator",
-    "StokesCppGenerator",
-    "ConstantAirCppGenerator",
-    "FentonAirCppGenerator",
-]
+WaveModelCppGenerator: TypeAlias = AiryCppGenerator | FentonCppGenerator | StokesCppGenerator
+AirPhaseModelCppGenerator: TypeAlias = ConstantAirCppGenerator | FentonAirCppGenerator

--- a/raschii/cpp/__init__.py
+++ b/raschii/cpp/__init__.py
@@ -1,0 +1,12 @@
+from .cpp_airy import AiryCppGenerator
+from .cpp_fenton import FentonCppGenerator
+from .cpp_stokes import StokesCppGenerator
+from .cpp_air import ConstantAirCppGenerator, FentonAirCppGenerator
+
+__all__ = [
+    "AiryCppGenerator",
+    "FentonCppGenerator",
+    "StokesCppGenerator",
+    "ConstantAirCppGenerator",
+    "FentonAirCppGenerator",
+]

--- a/raschii/cpp/cpp_air.py
+++ b/raschii/cpp/cpp_air.py
@@ -1,0 +1,102 @@
+from numpy import arange, cosh
+
+from ..common import np2py
+
+
+class ConstantAirCppGenerator:
+    """C++ code generator for ConstantAirPhase."""
+
+    def __init__(self, air):
+        self.air = air
+
+    def stream_function(self, frame="b"):
+        """
+        Return C++ code for evaluating the stream function of this specific
+        air phase model.
+        """
+        if frame == "b":
+            return f"{np2py(self.air.c)!r} * x[2]"
+        elif frame == "c":
+            return "0.0"
+
+    def velocity(self):
+        """
+        Return C++ code for evaluating the particle velocities of this specific
+        air phase model.
+        """
+        return ("0.0", "0.0")
+
+
+class FentonAirCppGenerator:
+    """C++ code generator for FentonAirPhase."""
+
+    def __init__(self, air):
+        self.air = air
+
+    def stream_function(self, frame="b"):
+        """
+        Return C++ code for evaluating the stream function of this specific
+        air phase model. The positive traveling direction is x[0] and the
+        vertical coordinate is x[2] which is zero at the bottom and equal to
+        +depth at the mean water level.
+        """
+        air = self.air
+        N = len(air.eta) - 1
+        J = arange(1, N + 1)
+        k = air.k
+
+        Jk = J * k
+        facs = air.B / cosh(Jk * air.height)
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        z2 = np2py(air.depth_water + air.height)
+        c = np2py(air.c)
+        Jk = np2py(Jk)
+        facs = np2py(facs)
+
+        z2_cpp = f"({z2!r} - x[2])"
+        cpp = " + ".join(
+            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * {z2_cpp})"
+            for i in range(N)
+        )
+
+        if frame == "b":
+            B0 = np2py(air.c)
+            return f"{B0!r} * x[2] + {cpp}"
+        elif frame == "c":
+            return cpp
+
+    def velocity(self):
+        """
+        Return C++ code for evaluating the particle velocities of this specific
+        air phase model. Returns the x and z components only with z positive
+        upwards. The positive traveling direction is x[0] and the vertical
+        coordinate is x[2] which is zero at the bottom and equal to +depth at
+        the mean water level.
+        """
+        air = self.air
+        N = len(air.eta) - 1
+        J = arange(1, N + 1)
+        k = air.k
+
+        Jk = J * k
+        facs = J * air.B * k / cosh(Jk * air.height)
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        z2 = np2py(air.depth_water + air.height)
+        c = np2py(air.c)
+        Jk = np2py(Jk)
+        facs = np2py(facs)
+
+        z2_cpp = f"({z2!r} - x[2])"
+        cpp_x = " + ".join(
+            f"{-facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * cosh({Jk[i]!r} * {z2_cpp})"
+            for i in range(N)
+        )
+        cpp_z = " + ".join(
+            f"{facs[i]!r} * sin({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * {z2_cpp})"
+            for i in range(N)
+        )
+        return (cpp_x, cpp_z)

--- a/raschii/cpp/cpp_air.py
+++ b/raschii/cpp/cpp_air.py
@@ -1,6 +1,6 @@
 from numpy import arange, cosh
 
-from ..common import np2py
+from ..common import Frame, np2py
 
 
 class ConstantAirCppGenerator:
@@ -9,15 +9,16 @@ class ConstantAirCppGenerator:
     def __init__(self, air):
         self.air = air
 
-    def stream_function(self, frame="b"):
+    def stream_function(self, frame=Frame.EARTH):
         """
         Return C++ code for evaluating the stream function of this specific
         air phase model.
         """
-        if frame == "b":
-            return f"{np2py(self.air.c)!r} * x[2]"
-        elif frame == "c":
+        c = np2py(self.air.c)
+        if frame == Frame.EARTH:
             return "0.0"
+        elif frame == Frame.WAVE:
+            return f"-{c!r} * x[2]"
 
     def velocity(self):
         """
@@ -33,7 +34,7 @@ class FentonAirCppGenerator:
     def __init__(self, air):
         self.air = air
 
-    def stream_function(self, frame="b"):
+    def stream_function(self, frame=Frame.EARTH):
         """
         Return C++ code for evaluating the stream function of this specific
         air phase model. The positive traveling direction is x[0] and the
@@ -61,10 +62,10 @@ class FentonAirCppGenerator:
             for i in range(N)
         )
 
-        if frame == "b":
+        if frame == Frame.EARTH:
             B0 = np2py(air.c)
             return f"{B0!r} * x[2] + {cpp}"
-        elif frame == "c":
+        elif frame == Frame.WAVE:
             return cpp
 
     def velocity(self):

--- a/raschii/cpp/cpp_airy.py
+++ b/raschii/cpp/cpp_airy.py
@@ -1,0 +1,66 @@
+from math import sinh
+
+from ..common import RaschiiError, blend_air_and_wave_velocity_cpp, np2py
+
+
+class AiryCppGenerator:
+    """C++ code generator for AiryWave."""
+
+    def __init__(self, wave):
+        self.wave = wave
+
+    def elevation(self):
+        """
+        Return C++ code for evaluating the elevation of this specific wave.
+        The positive traveling direction is x[0]
+        """
+        wave = self.wave
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        depth = np2py(wave.depth)
+        height = np2py(wave.height)
+        k = np2py(wave.k)
+        c = np2py(wave.c)
+
+        return f"{depth!r} + {height!r} / 2.0 * cos({k!r} * (x[0] - {c!r} * t))"
+
+    def velocity(self, all_points_wet=False):
+        """
+        Return C++ code for evaluating the particle velocities of this specific
+        wave. Returns the x and z components only with z positive upwards. The
+        positive traveling direction is x[0] and the vertical coordinate is x[2]
+        which is zero at the bottom and equal to +depth at the mean water level.
+        """
+        wave = self.wave
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        H = float(wave.height)
+        k = float(wave.k)
+        d = float(wave.depth)
+        w = float(wave.omega)
+        a = float(w * H / (2 * sinh(k * d)))
+
+        cpp_x = f"{a!r} * cosh({k!r} * x[2]) * cos({k!r} * x[0] - {w!r} * t)"
+        cpp_z = f"{a!r} * sinh({k!r} * x[2]) * sin({k!r} * x[0] - {w!r} * t)"
+
+        if all_points_wet:
+            return cpp_x, cpp_z
+
+        # Handle velocities above the free surface
+        e_cpp = self.elevation()
+        cpp_ax = cpp_az = None
+        cpp_psiw = cpp_psia = cpp_slope = None
+        if wave.air is not None:
+            cpp_ax, cpp_az = wave.air.cpp.velocity()
+            cpp_psiw = self.stream_function(frame="c")   # not implemented for Airy
+            cpp_psia = wave.air.cpp.stream_function(frame="c")
+            cpp_slope = self.slope()                      # not implemented for Airy
+
+        cpp_x = blend_air_and_wave_velocity_cpp(
+            cpp_x, cpp_ax, e_cpp, "x", wave.eta_eps, wave.air, cpp_psiw, cpp_psia, cpp_slope
+        )
+        cpp_z = blend_air_and_wave_velocity_cpp(
+            cpp_z, cpp_az, e_cpp, "z", wave.eta_eps, wave.air, cpp_psiw, cpp_psia, cpp_slope
+        )
+
+        return cpp_x, cpp_z

--- a/raschii/cpp/cpp_airy.py
+++ b/raschii/cpp/cpp_airy.py
@@ -1,6 +1,6 @@
 from math import sinh
 
-from ..common import RaschiiError, blend_air_and_wave_velocity_cpp, np2py
+from ..common import Frame, blend_air_and_wave_velocity_cpp, np2py
 
 
 class AiryCppGenerator:
@@ -52,9 +52,9 @@ class AiryCppGenerator:
         cpp_psiw = cpp_psia = cpp_slope = None
         if wave.air is not None:
             cpp_ax, cpp_az = wave.air.cpp.velocity()
-            cpp_psiw = self.stream_function(frame="c")   # not implemented for Airy
-            cpp_psia = wave.air.cpp.stream_function(frame="c")
-            cpp_slope = self.slope()                      # not implemented for Airy
+            cpp_psiw = self.stream_function(frame=Frame.WAVE)  # not implemented for Airy
+            cpp_psia = wave.air.cpp.stream_function(frame=Frame.WAVE)
+            cpp_slope = self.slope()  # not implemented for Airy
 
         cpp_x = blend_air_and_wave_velocity_cpp(
             cpp_x, cpp_ax, e_cpp, "x", wave.eta_eps, wave.air, cpp_psiw, cpp_psia, cpp_slope
@@ -64,3 +64,11 @@ class AiryCppGenerator:
         )
 
         return cpp_x, cpp_z
+
+    def stream_function(self, frame: Frame = Frame.EARTH):
+        raise NotImplementedError(
+            "C++ code generation for stream function is not implemented for Airy waves"
+        )
+
+    def slope(self):
+        raise NotImplementedError("C++ code generation for slope is not implemented for Airy waves")

--- a/raschii/cpp/cpp_fenton.py
+++ b/raschii/cpp/cpp_fenton.py
@@ -1,0 +1,148 @@
+from numpy import arange, cosh
+
+from ..common import RaschiiError, blend_air_and_wave_velocity_cpp, np2py
+
+
+class FentonCppGenerator:
+    """C++ code generator for FentonWave."""
+
+    def __init__(self, wave):
+        self.wave = wave
+
+    def stream_function(self, frame="b"):
+        """
+        Return C++ code for evaluating the stream function of this specific
+        wave. The positive traveling direction is x[0] and the vertical
+        coordinate is x[2] which is zero at the bottom and equal to +depth at
+        the mean water level.
+        """
+        wave = self.wave
+        if wave.depth < 0:
+            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
+        N = len(wave.eta) - 1
+        J = arange(1, N + 1)
+        B = wave.data["B"]
+        k = wave.k
+
+        Jk = J * k
+        facs = B[1:] / cosh(Jk * wave.depth)
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        c = np2py(wave.c)
+        Jk = np2py(Jk)
+        facs = np2py(facs)
+
+        cpp = " + ".join(
+            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r}* t)) * sinh({Jk[i]!r} * x[2])"
+            for i in range(N)
+        )
+
+        if frame == "b":
+            return f"{np2py(B[0])!r} * x[2] + {cpp}"
+        elif frame == "c":
+            return cpp
+
+    def elevation(self):
+        """
+        Return C++ code for evaluating the elevation of this specific wave.
+        The positive traveling direction is x[0]
+        """
+        wave = self.wave
+        if wave.depth < 0:
+            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
+        N = wave.E.size - 1
+        facs = wave.E * 2 / N
+        facs[0] *= 0.5
+        facs[-1] *= 0.5
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        k = np2py(wave.k)
+        c = np2py(wave.c)
+        facs = np2py(facs)
+
+        code = " + ".join(
+            f"{facs[j]!r} * cos({j:d} * {k!r} * (x[0] - {c!r} * t))" for j in range(0, N + 1)
+        )
+        return code
+
+    def slope(self):
+        """
+        Return C++ code for evaluating the surface slope of this specific wave.
+        The positive traveling direction is x[0]
+        """
+        wave = self.wave
+        if wave.depth < 0:
+            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
+        N = wave.E.size - 1
+        facs = wave.E * 2 / N * wave.k * -1.0
+        facs[0] *= 0.5
+        facs[-1] *= 0.5
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        k = np2py(wave.k)
+        c = np2py(wave.c)
+        facs = np2py(facs)
+
+        code = " + ".join(
+            f"{facs[j]!r} * {j:d} * sin({j:d} * {k!r} * (x[0] - {c!r} * t))"
+            for j in range(0, N + 1)
+        )
+        return code
+
+    def velocity(self, all_points_wet=False):
+        """
+        Return C++ code for evaluating the particle velocities of this specific
+        wave. Returns the x and z components only with z positive upwards. The
+        positive traveling direction is x[0] and the vertical coordinate is x[2]
+        which is zero at the bottom and equal to +depth at the mean water level.
+        """
+        wave = self.wave
+        if wave.depth < 0:
+            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
+        N = len(wave.eta) - 1
+        J = arange(1, N + 1)
+        B = wave.data["B"]
+        k = wave.k
+
+        Jk = J * k
+        facs = J * B[1:] * k / cosh(Jk * wave.depth)
+
+        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
+        # We use repr to make Python output a "smart" amount of digits
+        c = np2py(wave.c)
+        Jk = np2py(Jk)
+        facs = np2py(facs)
+
+        cpp_x = " + ".join(
+            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * cosh({Jk[i]!r} * x[2])"
+            for i in range(N)
+        )
+        cpp_z = " + ".join(
+            f"{facs[i]!r} * sin({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * x[2])"
+            for i in range(N)
+        )
+
+        if all_points_wet:
+            return cpp_x, cpp_z
+
+        # Handle velocities above the free surface
+        e_cpp = self.elevation()
+        cpp_ax = cpp_az = None
+        cpp_psiw = cpp_psia = cpp_slope = None
+        if wave.air is not None:
+            cpp_ax, cpp_az = wave.air.cpp.velocity()
+            cpp_psiw = self.stream_function(frame="c")
+            cpp_psia = wave.air.cpp.stream_function(frame="c")
+            cpp_slope = self.slope()
+
+        cpp_x = blend_air_and_wave_velocity_cpp(
+            cpp_x, cpp_ax, e_cpp, "x", wave.eta_eps, wave.air, cpp_psiw, cpp_psia, cpp_slope
+        )
+        cpp_z = blend_air_and_wave_velocity_cpp(
+            cpp_z, cpp_az, e_cpp, "z", wave.eta_eps, wave.air, cpp_psiw, cpp_psia, cpp_slope
+        )
+
+        return cpp_x, cpp_z

--- a/raschii/cpp/cpp_fenton.py
+++ b/raschii/cpp/cpp_fenton.py
@@ -1,15 +1,22 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from numpy import arange, cosh
 
-from ..common import RaschiiError, blend_air_and_wave_velocity_cpp, np2py
+from ..common import Frame, RaschiiError, blend_air_and_wave_velocity_cpp, np2py
+
+if TYPE_CHECKING:
+    from ..fenton import FentonWave
 
 
 class FentonCppGenerator:
     """C++ code generator for FentonWave."""
 
-    def __init__(self, wave):
-        self.wave = wave
+    def __init__(self, wave: FentonWave):
+        self.wave: FentonWave = wave
 
-    def stream_function(self, frame="b"):
+    def stream_function(self, frame: Frame = Frame.EARTH):
         """
         Return C++ code for evaluating the stream function of this specific
         wave. The positive traveling direction is x[0] and the vertical
@@ -38,9 +45,9 @@ class FentonCppGenerator:
             for i in range(N)
         )
 
-        if frame == "b":
+        if frame == Frame.EARTH:
             return f"{np2py(B[0])!r} * x[2] + {cpp}"
-        elif frame == "c":
+        elif frame == Frame.WAVE:
             return cpp
 
     def elevation(self):
@@ -134,8 +141,8 @@ class FentonCppGenerator:
         cpp_psiw = cpp_psia = cpp_slope = None
         if wave.air is not None:
             cpp_ax, cpp_az = wave.air.cpp.velocity()
-            cpp_psiw = self.stream_function(frame="c")
-            cpp_psia = wave.air.cpp.stream_function(frame="c")
+            cpp_psiw = self.stream_function(frame=Frame.WAVE)
+            cpp_psia = wave.air.cpp.stream_function(frame=Frame.WAVE)
             cpp_slope = self.slope()
 
         cpp_x = blend_air_and_wave_velocity_cpp(

--- a/raschii/cpp/cpp_fenton.py
+++ b/raschii/cpp/cpp_fenton.py
@@ -7,7 +7,7 @@ from numpy import arange, cosh
 from ..common import Frame, RaschiiError, blend_air_and_wave_velocity_cpp, np2py
 
 if TYPE_CHECKING:
-    from ..fenton import FentonWave
+    from ..wave_fenton import FentonWave
 
 
 class FentonCppGenerator:

--- a/raschii/cpp/cpp_stokes.py
+++ b/raschii/cpp/cpp_stokes.py
@@ -1,0 +1,5 @@
+class StokesCppGenerator:
+    """C++ code generator for StokesWave. No methods implemented yet."""
+
+    def __init__(self, wave):
+        self.wave = wave

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -206,7 +206,7 @@ class FentonWave(WaveModel):
         t = t[:, newaxis] # shape (n_times, 1)
 
         N = len(self.eta) - 1
-        B = self.data['B']
+        B = self.data["B"]
         k = self.k
         c = self.c
         depth = self.depth
@@ -214,7 +214,7 @@ class FentonWave(WaveModel):
 
         phase = J * k * (x - c * t)[..., newaxis] # shape (n_times, n_points, N)
         kz = J * k * z[..., newaxis]              # shape (1, n_points, N)
-        kh = J * k * depth                           # shape (N,)
+        kh = J * k * depth                        # shape (N,)
 
         vel_x = k * sum(J * B[1:] * cos(phase) * cosh(kz) / cosh(kh), axis=-1)
         vel_z = k * sum(J * B[1:] * sin(phase) * sinh(kz) / cosh(kh), axis=-1)
@@ -270,7 +270,7 @@ class FentonWave(WaveModel):
         t = t[:, newaxis] # shape (n_times, 1)
 
         N = len(self.eta) - 1
-        B = self.data['B']
+        B = self.data["B"]
         k = self.k
         c = self.c
         depth = self.depth
@@ -278,7 +278,7 @@ class FentonWave(WaveModel):
 
         phase = J * k * (x - c * t)[..., newaxis] # shape (n_times, n_points, N)
         kz = J * k * z[..., newaxis]              # shape (1, n_points, N)
-        kh = J * k * depth                           # shape (N,)
+        kh = J * k * depth                        # shape (N,)
 
         acc_x = k * sum(J * B[1:] * J * k * c * sin(phase) * cosh(kz) / cosh(kh), axis=-1)
         acc_z = k * sum(J * B[1:] * J * k * -c * cos(phase) * sinh(kz) / cosh(kh), axis=-1)

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -1,32 +1,37 @@
 import math
+
 from numpy import (
-    pi,
-    cos,
-    sin,
-    zeros,
     arange,
-    isfinite,
-    newaxis,
-    asarray,
-    linspace,
-    cosh,
-    sinh,
     array,
+    asarray,
+    atleast_1d,
+    broadcast_arrays,
+    cos,
+    cosh,
+    isfinite,
+    linspace,
+    newaxis,
+    pi,
+    sin,
+    sinh,
+    stack,
+    sum,
+    zeros,
 )
-from numpy.typing import NDArray
 from numpy.linalg import solve
+from numpy.typing import NDArray
+
+from .base_classes import WaveModel
 from .common import (
     NonConvergenceError,
-    sinh_by_cosh,
+    RaschiiError,
+    blend_air_and_wave_velocity_cpp,
     cosh_by_cosh,
     cosh_ratio,
-    blend_air_and_wave_velocities,
-    blend_air_and_wave_velocity_cpp,
-    trapezoid_integration,
     np2py,
-    RaschiiError,
+    sinh_by_cosh,
+    trapezoid_integration,
 )
-from .base_classes import WaveModel
 
 
 class FentonWave(WaveModel):
@@ -44,7 +49,7 @@ class FentonWave(WaveModel):
         g: float = 9.81,
         relax: float = 0.5,
         maxiter: int = 500,
-        num_steps: int = None
+        num_steps: int | None = None,
     ):
         """
         Implement stream function waves based on the paper by Rienecker and
@@ -78,7 +83,9 @@ class FentonWave(WaveModel):
             self.order = 1
 
         # Find the coeffients through optimization
-        data = fenton_coefficients(height, depth, length, N, g, relax=relax, maxiter=maxiter, num_steps=num_steps)
+        data = fenton_coefficients(
+            height, depth, length, N, g, relax=relax, maxiter=maxiter, num_steps=num_steps
+        )
         self.set_data(data)
 
         # For evaluating velocities close to the free surface
@@ -129,19 +136,33 @@ class FentonWave(WaveModel):
         elif frame == "c":
             return psi
 
-    def surface_elevation(self, x: float | list[float], t: float = 0.0, include_depth: bool = True):
+    def surface_elevation(
+        self,
+        x: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
+        include_depth: bool = True,
+    ):
         """
         Compute the surface elevation at time t for position(s) x
         """
-        if isinstance(x, (float, int)):
-            x = array([x], float)
-        x = asarray(x)
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
+
+        x = atleast_1d(asarray(x, dtype=float))  # (n_x,)
+        t = atleast_1d(asarray(t, dtype=float))  # (T,)
 
         # Cosine transformation of the elevation
         N = len(self.eta) - 1
-        J = arange(0, N + 1)
+        J = arange(0, N + 1)  # (N+1,)
         k, c = self.k, self.c
-        eta = 2 * trapezoid_integration(self.E * cos(J * k * (x[:, newaxis] - c * t))) / N
+
+        # Reshape for (T, n_x, N+1) broadcasting
+        x_r = x[newaxis, :, newaxis]   # (1, n_x, 1)
+        t_r = t[:, newaxis, newaxis]   # (T, 1, 1)
+        J_r = J[newaxis, newaxis, :]   # (1, 1, N+1)
+
+        eta = 2 * trapezoid_integration(self.E * cos(J_r * k * (x_r - c * t_r)), axis=-1) / N
+        # eta shape: (T, n_x)
 
         if include_depth:
             if self.depth < 0:
@@ -151,7 +172,13 @@ class FentonWave(WaveModel):
             # Apply consistent water depth limitation with 'fenton_coefficients'
             subtract = 25 * self.length if self.depth < 0 else self.depth
 
-        return eta - subtract
+        result = eta - subtract
+
+        if t_was_scalar:
+            return result[0]   # (n_x,)
+        elif x_was_scalar:
+            return result[:, 0]  # (T,)
+        return result  # (T, n_x)
 
     def surface_slope(self, x, t=0):
         """
@@ -167,9 +194,15 @@ class FentonWave(WaveModel):
         k, c = self.k, self.c
         return -2 * trapezoid_integration(self.E * J * k * sin(J * k * (x[:, newaxis] - c * t))) / N
 
-    def velocity(self, x: NDArray, z: NDArray, t: NDArray = 0, all_points_wet: bool = False):
+    def velocity(
+        self,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
+        all_points_wet: bool = False,
+    ):
         """
-        Computes the horizontal and vertical fluid velocity at each position `(x, z)` at each time `t`. 
+        Computes the horizontal and vertical fluid velocity at each position `(x, z)` at each time `t`.
         Supports scalar and 1D array inputs, and will return the velocity corresponding to the inputs' shapes.
         The `x` and `z` inputs are broadcast together into `N` input points. The length of the `t` input specifies `T` unique times.
 
@@ -185,8 +218,10 @@ class FentonWave(WaveModel):
         Returns
         -------
         velocity : ndarray
-            The horizontal and vertical fluid velocity at each time `t` at each position `(x, z)`. The shape of the output is:
-            - (2,) if `x`, `z`, and `t` are scalars (where the first element is horizontal velocity and the second element is vertical velocity)
+            The horizontal and vertical fluid velocity at each time `t` at each position `(x, z)`.
+            The shape of the output is:
+            - (2,) if `x`, `z`, and `t` are scalars (where the first element is horizontal velocity
+              and the second element is vertical velocity)
             - (N, 2) if `x` or `z` are arrays and `t` is scalar
             - (T, 2) if `x` and `z` are scalars and `t` is an array
             - (T, N, 2) if `x` or `z` are arrays and `t` is an array
@@ -200,9 +235,9 @@ class FentonWave(WaveModel):
 
         x, z = broadcast_arrays(x, z)
 
-        x = x[newaxis, :] # shape (1, n_points)
-        z = z[newaxis, :] # shape (1, n_points)
-        t = t[:, newaxis] # shape (n_times, 1)
+        x = x[newaxis, :]  # shape (1, n_points)
+        z = z[newaxis, :]  # shape (1, n_points)
+        t = t[:, newaxis]  # shape (n_times, 1)
 
         N = len(self.eta) - 1
         B = self.data["B"]
@@ -211,9 +246,9 @@ class FentonWave(WaveModel):
         depth = self.depth
         J = arange(1, N + 1)
 
-        phase = J * k * (x - c * t)[..., newaxis] # shape (n_times, n_points, N)
-        kz = J * k * z[..., newaxis]              # shape (1, n_points, N)
-        kh = J * k * depth                        # shape (N,)
+        phase = J * k * (x - c * t)[..., newaxis]  # shape (n_times, n_points, N)
+        kz = J * k * z[..., newaxis]  # shape (1, n_points, N)
+        kh = J * k * depth  # shape (N,)
 
         vel_x = k * sum(J * B[1:] * cos(phase) * cosh(kz) / cosh(kh), axis=-1)
         vel_z = k * sum(J * B[1:] * sin(phase) * sinh(kz) / cosh(kh), axis=-1)
@@ -225,13 +260,16 @@ class FentonWave(WaveModel):
             pass
             # must be updated for new broadcasting rules
 
-        if time_is_scalar and point_is_scalar: return vel.squeeze() # shape (2,)
-        elif time_is_scalar: return vel[0]                          # shape (n_points, 2)
-        elif point_is_scalar: return vel[:, 0]                      # shape (n_times, 2)
-        
-        return vel # shape (n_times, n_points, 2)
-    
-    def acceleration(self, x: NDArray, z:NDArray, t: NDArray = 0, all_points_wet: bool = False):
+        if time_is_scalar and point_is_scalar:
+            return vel.squeeze()  # shape (2,)
+        elif time_is_scalar:
+            return vel[0]  # shape (n_points, 2)
+        elif point_is_scalar:
+            return vel[:, 0]  # shape (n_times, 2)
+
+        return vel  # shape (n_times, n_points, 2)
+
+    def acceleration(self, x: NDArray, z: NDArray, t: NDArray = 0, all_points_wet: bool = False):
         """
         Computes the horizontal and vertical fluid acceleration at each position `(x, z)` at each time `t`.
         Supports scalar and 1D array inputs, and will return the acceleration corresponding to the inputs' shapes.
@@ -264,9 +302,9 @@ class FentonWave(WaveModel):
 
         x, z = broadcast_arrays(x, z)
 
-        x = x[newaxis, :] # shape (1, n_points)
-        z = z[newaxis, :] # shape (1, n_points)
-        t = t[:, newaxis] # shape (n_times, 1)
+        x = x[newaxis, :]  # shape (1, n_points)
+        z = z[newaxis, :]  # shape (1, n_points)
+        t = t[:, newaxis]  # shape (n_times, 1)
 
         N = len(self.eta) - 1
         B = self.data["B"]
@@ -275,9 +313,9 @@ class FentonWave(WaveModel):
         depth = self.depth
         J = arange(1, N + 1)
 
-        phase = J * k * (x - c * t)[..., newaxis] # shape (n_times, n_points, N)
-        kz = J * k * z[..., newaxis]              # shape (1, n_points, N)
-        kh = J * k * depth                        # shape (N,)
+        phase = J * k * (x - c * t)[..., newaxis]  # shape (n_times, n_points, N)
+        kz = J * k * z[..., newaxis]  # shape (1, n_points, N)
+        kh = J * k * depth  # shape (N,)
 
         acc_x = k * sum(J * B[1:] * J * k * c * sin(phase) * cosh(kz) / cosh(kh), axis=-1)
         acc_z = k * sum(J * B[1:] * J * k * -c * cos(phase) * sinh(kz) / cosh(kh), axis=-1)
@@ -289,11 +327,14 @@ class FentonWave(WaveModel):
             pass
             # must be updated for new broadcasting rules
 
-        if time_is_scalar and point_is_scalar: return acc.squeeze() # shape (2,)
-        elif time_is_scalar: return acc[0]                          # shape (n_points, 2)
-        elif point_is_scalar: return acc[:, 0]                      # shape (n_times, 2)
-        
-        return acc # shape (n_times, n_points, 2)
+        if time_is_scalar and point_is_scalar:
+            return acc.squeeze()  # shape (2,)
+        elif time_is_scalar:
+            return acc[0]  # shape (n_points, 2)
+        elif point_is_scalar:
+            return acc[:, 0]  # shape (n_times, 2)
+
+        return acc  # shape (n_times, n_points, 2)
 
     def stream_function_cpp(self, frame="b"):
         """
@@ -432,9 +473,9 @@ class FentonWave(WaveModel):
 
     def velocity_potential(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
     ):
         """
         Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
@@ -447,15 +488,16 @@ class FentonWave(WaveModel):
         (``depth=-1``) an effective depth of 25 × wave_length is used internally;
         z should be supplied in the same coordinate system.
         """
-        if self.depth < 0:
-            depth = 25.0 * self.length
-        else:
-            depth = self.depth
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
 
-        if isinstance(x, (float, int)):
+        if x_was_scalar:
             x, z = [x], [z]
-        x = asarray(x, dtype=float)
-        z = asarray(z, dtype=float)
+        x = atleast_1d(asarray(x, dtype=float))  # (M,)
+        z = atleast_1d(asarray(z, dtype=float))  # (M,)
+        t = atleast_1d(asarray(t, dtype=float))  # (T,)
+
+        depth = 25.0 * self.length if self.depth < 0 else self.depth
 
         N = len(self.eta) - 1
         B = self.data["B"]
@@ -463,15 +505,23 @@ class FentonWave(WaveModel):
         c = self.c
         J = arange(1, N + 1)
 
-        # phi = sum_{j=1}^{N} B_j * cosh(j k z) / cosh(j k depth) * sin(j k (x - c t))
-        # cosh_ratio is used for numerical stability in deep water.
-        x2 = x[:, newaxis] - c * t  # (M, 1) for broadcasting with J
+        # Reshape for (T, M, N) broadcasting
+        x_r = x[newaxis, :, newaxis]   # (1, M, 1)
+        t_r = t[:, newaxis, newaxis]   # (T, 1, 1)
+        z_r = z[newaxis, :, newaxis]   # (1, M, 1)
+        J_r = J[newaxis, newaxis, :]   # (1, 1, N)
+
         phi = (
             B[1:]
-            * sin(J * k * x2)                                           # (M, N)
-            * cosh_ratio(J * k * z[:, newaxis], J * k * depth)          # (M, N)
-        ).sum(axis=1)
-        return phi
+            * sin(J_r * k * (x_r - c * t_r))           # (T, M, N)
+            * cosh_ratio(J_r * k * z_r, J_r * k * depth)  # (1, M, N)
+        ).sum(axis=-1)  # (T, M)
+
+        if t_was_scalar:
+            return phi[0]  # (M,)
+        elif x_was_scalar:
+            return phi[:, 0]  # (T,)
+        return phi  # (T, M)
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -43,6 +43,7 @@ class FentonWave(WaveModel):
         height: float,
         depth: float,
         length: float | None = None,
+        *,
         N: int = 5,
         period: float | None = None,
         air=None,

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -21,8 +21,9 @@ from numpy import (
 from numpy.linalg import solve
 from numpy.typing import NDArray
 
-from .base_classes import WaveModel
+from .base_classes import AirPhaseModel, WaveModel
 from .common import (
+    Frame,
     NonConvergenceError,
     RaschiiError,
     blend_air_and_wave_velocities,
@@ -46,7 +47,7 @@ class FentonWave(WaveModel):
         *,
         N: int = 5,
         period: float | None = None,
-        air=None,
+        air: AirPhaseModel | None = None,
         g: float = 9.81,
         relax: float = 0.5,
         maxiter: int = 500,
@@ -70,14 +71,29 @@ class FentonWave(WaveModel):
                 height=height, depth=depth, period=period, N=N, g=g, relax=relax
             )
 
-        self.height: float = height  #: The wave height
-        self.depth: float = depth  #: The water depth
-        self.length: float = length  #: The wave length
-        self.order: int = N  #: The approximation order
-        self.air = air  #: The optional air-phase model
-        self.g: float = g  #: The acceleration of gravity
-        self.relax: float = relax  #: The numerical relaxation in the optimization loop
-        self.warnings: str = ""  #: Warnings raised when generating this wave
+        #: The wave height
+        self.height: float = height
+
+        #: The water depth
+        self.depth: float = depth
+
+        #: The wave length
+        self.length: float = length
+
+        #: The approximation order
+        self.order: int = N
+
+        #: The optional air-phase model
+        self.air: AirPhaseModel | None = air
+
+        #: The acceleration of gravity
+        self.g: float = g
+
+        #: The numerical relaxation in the optimization loop
+        self.relax: float = relax
+
+        #: Warnings raised when generating this wave
+        self.warnings: str = ""
 
         if N < 1:
             self.warnings = "Fenton order must be at least 1, using order 1"
@@ -96,6 +112,7 @@ class FentonWave(WaveModel):
         if self.air is not None:
             self.air.set_wave(self)
 
+        # Niche use use case: Provide a C++ code generator for this wave model
         self.cpp = FentonCppGenerator(self)
 
     def set_data(self, data):
@@ -117,9 +134,13 @@ class FentonWave(WaveModel):
         J = arange(0, N + 1)
         self.E = trapezoid_integration(self.eta * cos(J * J[:, newaxis] * pi / N))
 
-    def stream_function(self, x, z, t=0, frame="b"):
+    def stream_function(self, x, z, t=0, frame=Frame.EARTH):
         """
-        Compute the stream function at time t for position(s) x
+        Compute the stream function at time t for position(s) x.
+
+        * frame: :class:`~raschii.Frame` – ``Frame.EARTH`` (default) includes
+          the constant base-flow term; ``Frame.WAVE`` returns only the
+          oscillatory part.
         """
         if isinstance(x, (float, int)):
             x, z = [x], [z]
@@ -134,10 +155,12 @@ class FentonWave(WaveModel):
 
         psi = (sinh(J * k * z2) / cosh(J * k * self.depth) * cos(J * k * x2)).dot(B[1:])
 
-        if frame == "b":
+        if frame == Frame.EARTH:
             return B[0] * z + psi
-        elif frame == "c":
+        elif frame == Frame.WAVE:
             return psi
+        else:
+            raise ValueError(f"Unknown frame {frame!r}; use Frame.EARTH or Frame.WAVE")
 
     def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         N = len(self.eta) - 1

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -136,49 +136,22 @@ class FentonWave(WaveModel):
         elif frame == "c":
             return psi
 
-    def surface_elevation(
-        self,
-        x: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        include_depth: bool = True,
-    ):
-        """
-        Compute the surface elevation at time t for position(s) x
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        x = atleast_1d(asarray(x, dtype=float))  # (n_x,)
-        t = atleast_1d(asarray(t, dtype=float))  # (T,)
-
-        # Cosine transformation of the elevation
+    def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         N = len(self.eta) - 1
-        J = arange(0, N + 1)  # (N+1,)
+        J = arange(0, N + 1)
         k, c = self.k, self.c
-
-        # Reshape for (T, n_x, N+1) broadcasting
-        x_r = x[newaxis, :, newaxis]   # (1, n_x, 1)
-        t_r = t[:, newaxis, newaxis]   # (T, 1, 1)
-        J_r = J[newaxis, newaxis, :]   # (1, 1, N+1)
-
+        x_r = x[newaxis, :, newaxis]  # (1, n_x, 1)
+        t_r = t[:, newaxis, newaxis]  # (T, 1, 1)
+        J_r = J[newaxis, newaxis, :]  # (1, 1, N+1)
         eta = 2 * trapezoid_integration(self.E * cos(J_r * k * (x_r - c * t_r)), axis=-1) / N
         # eta shape: (T, n_x)
-
         if include_depth:
             if self.depth < 0:
                 raise RaschiiError("Cannot include depth in elevation for infinite depth")
             subtract = 0.0
         else:
-            # Apply consistent water depth limitation with 'fenton_coefficients'
             subtract = 25 * self.length if self.depth < 0 else self.depth
-
-        result = eta - subtract
-
-        if t_was_scalar:
-            return result[0]   # (n_x,)
-        elif x_was_scalar:
-            return result[:, 0]  # (T,)
-        return result  # (T, n_x)
+        return eta - subtract
 
     def surface_slope(self, x, t=0):
         """
@@ -194,50 +167,10 @@ class FentonWave(WaveModel):
         k, c = self.k, self.c
         return -2 * trapezoid_integration(self.E * J * k * sin(J * k * (x[:, newaxis] - c * t))) / N
 
-    def velocity(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        all_points_wet: bool = False,
-    ):
-        """
-        Computes the horizontal and vertical fluid velocity at each position `(x, z)` at each time `t`.
-        Supports scalar and 1D array inputs, and will return the velocity corresponding to the inputs' shapes.
-        The `x` and `z` inputs are broadcast together into `N` input points. The length of the `t` input specifies `T` unique times.
-
-        Parameters
-        ----------
-        x : float | array
-            Horizontal position(s)
-        z : float | array
-            Vertical position(s) where z = 0 at the sea floor and z = depth at the free surface
-        t : float | array = 0
-            Time(s) at which to compute the velocity at each (x, z) point
-
-        Returns
-        -------
-        velocity : ndarray
-            The horizontal and vertical fluid velocity at each time `t` at each position `(x, z)`.
-            The shape of the output is:
-            - (2,) if `x`, `z`, and `t` are scalars (where the first element is horizontal velocity
-              and the second element is vertical velocity)
-            - (N, 2) if `x` or `z` are arrays and `t` is scalar
-            - (T, 2) if `x` and `z` are scalars and `t` is an array
-            - (T, N, 2) if `x` or `z` are arrays and `t` is an array
-        """
-        time_is_scalar = asarray(t).ndim == 0
-        point_is_scalar = asarray(x).ndim == 0 and asarray(z).ndim == 0
-
-        x = atleast_1d(x)
-        z = atleast_1d(z)
-        t = atleast_1d(t)
-
-        x, z = broadcast_arrays(x, z)
-
-        x = x[newaxis, :]  # shape (1, n_points)
-        z = z[newaxis, :]  # shape (1, n_points)
-        t = t[:, newaxis]  # shape (n_times, 1)
+    def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
+        x = x[newaxis, :]  # (1, n_points)
+        z = z[newaxis, :]  # (1, n_points)
+        t = t[:, newaxis]  # (n_times, 1)
 
         N = len(self.eta) - 1
         B = self.data["B"]
@@ -246,28 +179,19 @@ class FentonWave(WaveModel):
         depth = self.depth
         J = arange(1, N + 1)
 
-        phase = J * k * (x - c * t)[..., newaxis]  # shape (n_times, n_points, N)
-        kz = J * k * z[..., newaxis]  # shape (1, n_points, N)
-        kh = J * k * depth  # shape (N,)
+        phase = J * k * (x - c * t)[..., newaxis]  # (n_times, n_points, N)
+        kz = J * k * z[..., newaxis]  # (1, n_points, N)
+        kh = J * k * depth  # (N,)
 
         vel_x = k * sum(J * B[1:] * cos(phase) * cosh(kz) / cosh(kh), axis=-1)
         vel_z = k * sum(J * B[1:] * sin(phase) * sinh(kz) / cosh(kh), axis=-1)
-
-        vel = stack([vel_x, vel_z], axis=-1)  # shape (n_times, n_points, 2)
+        vel = stack([vel_x, vel_z], axis=-1)  # (n_times, n_points, 2)
 
         if not all_points_wet:
-            # blend_air_and_wave_velocities(x, z, t, self, self.air, vel, self.eta_eps)
+            # blend_air_and_wave_velocities needs updating for new shape convention
             pass
-            # must be updated for new broadcasting rules
 
-        if time_is_scalar and point_is_scalar:
-            return vel.squeeze()  # shape (2,)
-        elif time_is_scalar:
-            return vel[0]  # shape (n_points, 2)
-        elif point_is_scalar:
-            return vel[:, 0]  # shape (n_times, 2)
-
-        return vel  # shape (n_times, n_points, 2)
+        return vel
 
     def acceleration(self, x: NDArray, z: NDArray, t: NDArray = 0, all_points_wet: bool = False):
         """
@@ -471,57 +395,20 @@ class FentonWave(WaveModel):
 
         return cpp_x, cpp_z
 
-    def velocity_potential(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-    ):
-        """
-        Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
-
-        z is measured from the sea floor (z=0 at bottom, z≈depth at calm surface).
-        The gradient ∇φ equals the oscillatory fluid velocity as returned by
-        :meth:`velocity`; the mean-flow current term (B₀·x) is excluded.
-
-        Works for both finite and infinite depth.  For infinite-depth waves
-        (``depth=-1``) an effective depth of 25 × wave_length is used internally;
-        z should be supplied in the same coordinate system.
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        if x_was_scalar:
-            x, z = [x], [z]
-        x = atleast_1d(asarray(x, dtype=float))  # (M,)
-        z = atleast_1d(asarray(z, dtype=float))  # (M,)
-        t = atleast_1d(asarray(t, dtype=float))  # (T,)
-
+    def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
         depth = 25.0 * self.length if self.depth < 0 else self.depth
-
         N = len(self.eta) - 1
         B = self.data["B"]
         k = self.k
         c = self.c
         J = arange(1, N + 1)
-
-        # Reshape for (T, M, N) broadcasting
-        x_r = x[newaxis, :, newaxis]   # (1, M, 1)
-        t_r = t[:, newaxis, newaxis]   # (T, 1, 1)
-        z_r = z[newaxis, :, newaxis]   # (1, M, 1)
-        J_r = J[newaxis, newaxis, :]   # (1, 1, N)
-
-        phi = (
-            B[1:]
-            * sin(J_r * k * (x_r - c * t_r))           # (T, M, N)
-            * cosh_ratio(J_r * k * z_r, J_r * k * depth)  # (1, M, N)
+        x_r = x[newaxis, :, newaxis]  # (1, M, 1)
+        t_r = t[:, newaxis, newaxis]  # (T, 1, 1)
+        z_r = z[newaxis, :, newaxis]  # (1, M, 1)
+        J_r = J[newaxis, newaxis, :]  # (1, 1, N)
+        return (
+            B[1:] * sin(J_r * k * (x_r - c * t_r)) * cosh_ratio(J_r * k * z_r, J_r * k * depth)
         ).sum(axis=-1)  # (T, M)
-
-        if t_was_scalar:
-            return phi[0]  # (M,)
-        elif x_was_scalar:
-            return phi[:, 0]  # (T,)
-        return phi  # (T, M)
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -25,13 +25,13 @@ from .base_classes import WaveModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
-    blend_air_and_wave_velocity_cpp,
     cosh_by_cosh,
     cosh_ratio,
     np2py,
     sinh_by_cosh,
     trapezoid_integration,
 )
+from .cpp import FentonCppGenerator
 
 
 class FentonWave(WaveModel):
@@ -94,6 +94,8 @@ class FentonWave(WaveModel):
         # Provide velocities also in the air phase
         if self.air is not None:
             self.air.set_wave(self)
+
+        self.cpp = FentonCppGenerator(self)
 
     def set_data(self, data):
         """
@@ -259,141 +261,6 @@ class FentonWave(WaveModel):
             return acc[:, 0]  # shape (n_times, 2)
 
         return acc  # shape (n_times, n_points, 2)
-
-    def stream_function_cpp(self, frame="b"):
-        """
-        Return C++ code for evaluating the stream function of this specific
-        wave. The positive traveling direction is x[0] and the vertical
-        coordinate is x[2] which is zero at the bottom and equal to +depth at
-        the mean water level.
-        """
-        if self.depth < 0:
-            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
-        N = len(self.eta) - 1
-        J = arange(1, N + 1)
-        B = self.data["B"]
-        k = self.k
-
-        Jk = J * k
-        facs = B[1:] / cosh(Jk * self.depth)
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        c = np2py(self.c)
-        Jk = np2py(Jk)
-        facs = np2py(facs)
-
-        cpp = " + ".join(
-            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r}* t)) * sinh({Jk[i]!r} * x[2])"
-            for i in range(N)
-        )
-
-        if frame == "b":
-            return f"{np2py(B[0])!r} * x[2] + {cpp}"
-        elif frame == "c":
-            return cpp
-
-    def elevation_cpp(self):
-        """
-        Return C++ code for evaluating the elevation of this specific wave.
-        The positive traveling direction is x[0]
-        """
-        if self.depth < 0:
-            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
-        N = self.E.size - 1
-        facs = self.E * 2 / N
-        facs[0] *= 0.5
-        facs[-1] *= 0.5
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        k = np2py(self.k)
-        c = np2py(self.c)
-        facs = np2py(facs)
-
-        code = " + ".join(
-            f"{facs[j]!r} * cos({j:d} * {k!r} * (x[0] - {c!r} * t))" for j in range(0, N + 1)
-        )
-        return code
-
-    def slope_cpp(self):
-        """
-        Return C++ code for evaluating the surface slope of this specific wave.
-        The positive traveling direction is x[0]
-        """
-        if self.depth < 0:
-            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
-        N = self.E.size - 1
-        facs = self.E * 2 / N * self.k * -1.0
-        facs[0] *= 0.5
-        facs[-1] *= 0.5
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        k = np2py(self.k)
-        c = np2py(self.c)
-        facs = np2py(facs)
-
-        code = " + ".join(
-            f"{facs[j]!r} * {j:d} * sin({j:d} * {k!r} * (x[0] - {c!r} * t))"
-            for j in range(0, N + 1)
-        )
-        return code
-
-    def velocity_cpp(self, all_points_wet=False):
-        """
-        Return C++ code for evaluating the particle velocities of this specific
-        wave. Returns the x and z components only with z positive upwards. The
-        positive traveling direction is x[0] and the vertical coordinate is x[2]
-        which is zero at the bottom and equal to +depth at the mean water level.
-        """
-        if self.depth < 0:
-            raise RaschiiError("Cannot currently generate C++ code for infinite depth waves")
-        N = len(self.eta) - 1
-        J = arange(1, N + 1)
-        B = self.data["B"]
-        k = self.k
-        c = self.c
-
-        Jk = J * k
-        facs = J * B[1:] * k / cosh(Jk * self.depth)
-
-        # Repr of np.float64(42.0) is "np.float64(42.0)" and not "42.0"
-        # We use repr to make Python output a "smart" amount of digits
-        c = np2py(self.c)
-        Jk = np2py(Jk)
-        facs = np2py(facs)
-
-        cpp_x = " + ".join(
-            f"{facs[i]!r} * cos({Jk[i]!r} * (x[0] - {c!r} * t)) * cosh({Jk[i]!r} * x[2])"
-            for i in range(N)
-        )
-        cpp_z = " + ".join(
-            f"{facs[i]!r} * sin({Jk[i]!r} * (x[0] - {c!r} * t)) * sinh({Jk[i]!r} * x[2])"
-            for i in range(N)
-        )
-
-        if all_points_wet:
-            return cpp_x, cpp_z
-
-        # Handle velocities above the free surface
-        e_cpp = self.elevation_cpp()
-        cpp_ax = cpp_az = None
-        cpp_psiw = cpp_psia = cpp_slope = None
-        if self.air is not None:
-            cpp_ax, cpp_az = self.air.velocity_cpp()
-            cpp_psiw = self.stream_function_cpp(frame="c")
-            cpp_psia = self.air.stream_function_cpp(frame="c")
-            cpp_slope = self.slope_cpp()
-
-        cpp_x = blend_air_and_wave_velocity_cpp(
-            cpp_x, cpp_ax, e_cpp, "x", self.eta_eps, self.air, cpp_psiw, cpp_psia, cpp_slope
-        )
-        cpp_z = blend_air_and_wave_velocity_cpp(
-            cpp_z, cpp_az, e_cpp, "z", self.eta_eps, self.air, cpp_psiw, cpp_psia, cpp_slope
-        )
-
-        return cpp_x, cpp_z
 
     def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
         depth = 25.0 * self.length if self.depth < 0 else self.depth

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -25,9 +25,9 @@ from .base_classes import WaveModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
+    blend_air_and_wave_velocities,
     cosh_by_cosh,
     cosh_ratio,
-    np2py,
     sinh_by_cosh,
     trapezoid_integration,
 )
@@ -170,6 +170,7 @@ class FentonWave(WaveModel):
         return -2 * trapezoid_integration(self.E * J * k * sin(J * k * (x[:, newaxis] - c * t))) / N
 
     def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
+        x_1d, z_1d, t_1d = x, z, t  # save (N,), (N,), (T,) before reshaping
         x = x[newaxis, :]  # (1, n_points)
         z = z[newaxis, :]  # (1, n_points)
         t = t[:, newaxis]  # (n_times, 1)
@@ -190,8 +191,10 @@ class FentonWave(WaveModel):
         vel = stack([vel_x, vel_z], axis=-1)  # (n_times, n_points, 2)
 
         if not all_points_wet:
-            # blend_air_and_wave_velocities needs updating for new shape convention
-            pass
+            for i, ti in enumerate(t_1d):
+                blend_air_and_wave_velocities(
+                    x_1d, z_1d, float(ti), self, self.air, vel[i], self.eta_eps
+                )
 
         return vel
 

--- a/raschii/fenton.py
+++ b/raschii/fenton.py
@@ -222,42 +222,56 @@ class FentonWave(WaveModel):
 
         return vel
 
-    def acceleration(self, x: NDArray, z: NDArray, t: NDArray = 0, all_points_wet: bool = False):
+    def acceleration(
+        self,
+        x: float | NDArray,
+        z: float | NDArray,
+        t: float | NDArray = 0.0,
+        all_points_wet: bool = False,
+    ):
         """
-        Computes the horizontal and vertical fluid acceleration at each position `(x, z)` at each time `t`.
-        Supports scalar and 1D array inputs, and will return the acceleration corresponding to the inputs' shapes.
-        The `x` and `z` inputs are broadcast together into `N` input points. The length of the `t` input specifies `T` unique times.
+        Compute the horizontal and vertical fluid acceleration at each position
+        ``(x, z)`` at each time ``t``.
+
+        .. note::
+
+           This method is **water-phase only**.  Acceleration above the free
+           surface is set to zero when ``all_points_wet=False`` (the default).
+           Air-phase blending for accelerations is not yet implemented.  If an
+           air model is attached and you query points above the free surface with
+           ``all_points_wet=False``, a :exc:`~raschii.RaschiiError` is raised.
 
         Parameters
         ----------
         x : float | array
-            Horizontal position(s)
+            Horizontal position(s).
         z : float | array
-            Vertical position(s) where z = 0 at the sea floor and z = depth at the free surface
-        t : float | array = 0
-            Time(s) at which to compute the acceleration at each (x, z) point
+            Vertical position(s) where z = 0 at the sea floor and
+            z = depth at the free surface.
+        t : float | array, optional
+            Time(s) at which to compute the acceleration (default 0).
+        all_points_wet : bool, optional
+            If ``True``, evaluate the wave formula at all points regardless of
+            whether they are above the free surface.  Useful for testing.
 
         Returns
         -------
-        acceleration : ndarray
-            The horizontal and vertical fluid acceleration at each time `t` at each position `(x, z)`. The shape of the output is:
-            - (2,) if `x`, `z`, and `t` are scalars (where the first element is horizontal acceleration and the second element is vertical acceleration)
-            - (N, 2) if `x` or `z` are arrays and `t` is scalar
-            - (T, 2) if `x` and `z` are scalars and `t` is an array
-            - (T, N, 2) if `x` or `z` are arrays and `t` is an array
+        ndarray
+            Shape ``(2,)`` for scalar inputs, ``(N, 2)`` for array points and
+            scalar time, ``(T, 2)`` for scalar point and array time,
+            ``(T, N, 2)`` for array points and array time.
         """
         time_is_scalar = asarray(t).ndim == 0
         point_is_scalar = asarray(x).ndim == 0 and asarray(z).ndim == 0
 
-        x = atleast_1d(x)
-        z = atleast_1d(z)
-        t = atleast_1d(t)
+        x_1d = atleast_1d(asarray(x, dtype=float))
+        z_1d = atleast_1d(asarray(z, dtype=float))
+        t_1d = atleast_1d(asarray(t, dtype=float))
+        x_1d, z_1d = broadcast_arrays(x_1d, z_1d)
 
-        x, z = broadcast_arrays(x, z)
-
-        x = x[newaxis, :]  # shape (1, n_points)
-        z = z[newaxis, :]  # shape (1, n_points)
-        t = t[:, newaxis]  # shape (n_times, 1)
+        x = x_1d[newaxis, :]  # shape (1, n_points)
+        z = z_1d[newaxis, :]  # shape (1, n_points)
+        t = t_1d[:, newaxis]  # shape (n_times, 1)
 
         N = len(self.eta) - 1
         B = self.data["B"]
@@ -276,9 +290,25 @@ class FentonWave(WaveModel):
         acc = stack([acc_x, acc_z], axis=-1)  # shape (n_times, n_points, 2)
 
         if not all_points_wet:
-            # blend_air_and_wave_velocities(x, z, t, self, self.air, vel, self.eta_eps)
-            pass
-            # must be updated for new broadcasting rules
+            if self.air is not None:
+                eta = asarray(
+                    [self.surface_elevation(x_1d, float(ti)) for ti in t_1d], dtype=float
+                )  # (n_times, n_points)
+                above = z_1d[newaxis, :] > eta + self.eta_eps  # (n_times, n_points)
+                if above.any():
+                    raise RaschiiError(
+                        "acceleration() does not support air-phase blending. "
+                        "Points above the free surface were detected. "
+                        "Use all_points_wet=True to evaluate the raw wave formula, "
+                        "or only query points below the free surface."
+                    )
+            else:
+                # Zero out accelerations above the free surface (no air model)
+                for i, ti in enumerate(t_1d):
+                    eta_i = asarray(self.surface_elevation(x_1d, float(ti)), dtype=float)
+                    above_i = z_1d > eta_i + self.eta_eps
+                    if above_i.any():
+                        acc[i, above_i] = 0.0
 
         if time_is_scalar and point_is_scalar:
             return acc.squeeze()  # shape (2,)

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -1,6 +1,6 @@
 from math import pi, sinh, tanh, exp, sqrt, pow
 import numpy as np
-from .common import blend_air_and_wave_velocities, RasciiError, NonConvergenceError
+from .common import blend_air_and_wave_velocities, RaschiiError, NonConvergenceError
 from .swd_tools import SwdShape1and2
 from .base_classes import WaveModel
 
@@ -32,7 +32,7 @@ class StokesWave(WaveModel):
         """
         if length is None:
             if period is None:
-                raise RasciiError("Either length or period must be given, both are None!")
+                raise RaschiiError("Either length or period must be given, both are None!")
             length = compute_length_from_period(height=height, depth=depth, period=period, N=N, g=g)
 
         self.height: float = height  #: The wave height
@@ -114,7 +114,7 @@ class StokesWave(WaveModel):
 
         if include_depth:
             if self.depth < 0:
-                raise RasciiError("Cannot include depth in elevation for infinite depth")
+                raise RaschiiError("Cannot include depth in elevation for infinite depth")
             offset = self.depth
         else:
             offset = 0.0
@@ -133,7 +133,7 @@ class StokesWave(WaveModel):
         where z is 0 at the bottom and equal to depth at the free surface
         """
         if self.depth < 0:
-            raise RasciiError("Cannot currently compute velocity for infinite depth waves")
+            raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
         if isinstance(x, (float, int)):
             x, z = [x], [z]
         x = np.asarray(x, dtype=float)

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -16,6 +16,7 @@ class StokesWave(WaveModel):
         height: float,
         depth: float,
         length: float | None = None,
+        *,
         N: int = 5,
         period: float | None = None,
         air=None,

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -3,7 +3,7 @@ from math import exp, pi, pow, sinh, sqrt, tanh
 import numpy as np
 from numpy.typing import NDArray
 
-from .base_classes import WaveModel
+from .base_classes import WaveModel, AirPhaseModel
 from .common import NonConvergenceError, RaschiiError, blend_air_and_wave_velocities
 
 
@@ -19,7 +19,7 @@ class StokesWave(WaveModel):
         *,
         N: int = 5,
         period: float | None = None,
-        air=None,
+        air: AirPhaseModel | None = None,
         g: float = 9.81,
     ):
         """
@@ -38,13 +38,26 @@ class StokesWave(WaveModel):
                 raise RaschiiError("Either length or period must be given, both are None!")
             length = compute_length_from_period(height=height, depth=depth, period=period, N=N, g=g)
 
-        self.height: float = height  #: The wave height
-        self.depth: float = depth  #: The water depth
-        self.length: float = length  #: The wave length
-        self.order: int = N  #: The approximation order
-        self.air = air  #: The optional air-phase model
-        self.g: float = g  #: The acceleration of gravity
-        self.warnings: str = ""  #: Warnings raised when generating this wave
+        #: The wave height
+        self.height: float = height
+
+        #: The water depth
+        self.depth: float = depth
+
+        #: The wave length
+        self.length: float = length
+
+        #: The approximation order
+        self.order: int = N
+
+        #: The optional air-phase model
+        self.air: AirPhaseModel | None = air
+
+        #: The acceleration of gravity
+        self.g: float = g
+
+        #: Warnings raised when generating this wave
+        self.warnings: str = ""
 
         if N < 1:
             self.warnings = "Stokes order must be at least 1, using order 1"
@@ -54,6 +67,7 @@ class StokesWave(WaveModel):
             self.order = 5
 
         # Find the coeffients through explicit formulas
+        #: The wave number
         self.k = 2 * pi / length  # The wave number
         data = stokes_coefficients(self.k * depth, self.order)
         self.set_data(data)
@@ -67,6 +81,7 @@ class StokesWave(WaveModel):
 
         from .cpp import StokesCppGenerator
 
+        # Niche use use case: Provide a C++ code generator for this wave model
         self.cpp = StokesCppGenerator(self)
 
     def set_data(self, data):

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -1,7 +1,10 @@
-from math import pi, sinh, tanh, exp, sqrt, pow
+from math import exp, pi, pow, sinh, sqrt, tanh
+
 import numpy as np
-from .common import blend_air_and_wave_velocities, RaschiiError, NonConvergenceError
+from numpy.typing import NDArray
+
 from .base_classes import WaveModel
+from .common import NonConvergenceError, RaschiiError, blend_air_and_wave_velocities
 
 
 class StokesWave(WaveModel):
@@ -85,14 +88,23 @@ class StokesWave(WaveModel):
         self.T = self.length / self.c  # Wave period
         self.omega = self.c * self.k  # Wave frequency
 
-    def surface_elevation(self, x: float | list[float], t: float = 0.0, include_depth: bool = True):
+    def surface_elevation(
+        self,
+        x: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
+        include_depth: bool = True,
+    ):
         """
         Compute the surface elavation at time t for position(s) x
         """
-        if isinstance(x, (float, int)):
-            x = np.array([x], float)
-        x = np.asarray(x)
-        x2 = x - self.c * t
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
+
+        x = np.atleast_1d(np.asarray(x, dtype=float))  # (N,)
+        t = np.atleast_1d(np.asarray(t, dtype=float))  # (T,)
+
+        # x2 shape: (T, N) — broadcast for all (t, x) combinations
+        x2 = x[np.newaxis, :] - self.c * t[:, np.newaxis]
 
         k = self.k
         eps = k * self.height / 2
@@ -110,6 +122,7 @@ class StokesWave(WaveModel):
                 + D["B55"] * cos(5 * k * x2)
             )
         ) / k
+        # eta shape: (T, N)
 
         if include_depth:
             if self.depth < 0:
@@ -118,13 +131,19 @@ class StokesWave(WaveModel):
         else:
             offset = 0.0
 
-        return offset + eta
+        result = offset + eta
+
+        if t_was_scalar:
+            return result[0]   # (N,)
+        elif x_was_scalar:
+            return result[:, 0]  # (T,)
+        return result  # (T, N)
 
     def velocity(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
         all_points_wet: bool = False,
     ):
         """
@@ -133,11 +152,21 @@ class StokesWave(WaveModel):
         """
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
-        if isinstance(x, (float, int)):
-            x, z = [x], [z]
-        x = np.asarray(x, dtype=float)
-        z = np.asarray(z, dtype=float)
-        x2 = x - self.c * t
+
+        time_is_scalar = np.asarray(t).ndim == 0
+        point_is_scalar = np.asarray(x).ndim == 0 and np.asarray(z).ndim == 0
+
+        x = np.atleast_1d(np.asarray(x, dtype=float))
+        z = np.atleast_1d(np.asarray(z, dtype=float))
+        t = np.atleast_1d(np.asarray(t, dtype=float))
+
+        x, z = np.broadcast_arrays(x, z)
+
+        x = x[np.newaxis, :]  # (1, n_points)
+        z = z[np.newaxis, :]  # (1, n_points)
+        t = t[:, np.newaxis]  # (n_times, 1)
+
+        x2 = x - self.c * t  # (n_times, n_points)
 
         def my_cosh_cos(i, j):
             n = "A%d%d" % (i, j)
@@ -168,8 +197,7 @@ class StokesWave(WaveModel):
                 )
 
         eps = self.k * self.height / 2
-        vel = np.zeros((x.size, 2), float)
-        vel[:, 0] = (
+        vel_x = (
             my_cosh_cos(1, 1)
             + my_cosh_cos(2, 2)
             + my_cosh_cos(3, 1)
@@ -180,7 +208,7 @@ class StokesWave(WaveModel):
             + my_cosh_cos(5, 3)
             + my_cosh_cos(5, 5)
         )
-        vel[:, 1] = (
+        vel_z = (
             my_sinh_sin(1, 1)
             + my_sinh_sin(2, 2)
             + my_sinh_sin(3, 1)
@@ -191,12 +219,20 @@ class StokesWave(WaveModel):
             + my_sinh_sin(5, 3)
             + my_sinh_sin(5, 5)
         )
-        vel *= self.data["C0"] * sqrt(self.g / self.k**3)
+        scale = self.data["C0"] * sqrt(self.g / self.k**3)
+        vel = np.stack([vel_x * scale, vel_z * scale], axis=-1)  # (n_times, n_points, 2)
 
         if not all_points_wet:
-            blend_air_and_wave_velocities(x, z, t, self, self.air, vel, self.eta_eps)
+            # blend_air_and_wave_velocities needs updating for new shape convention
+            pass
 
-        return vel
+        if time_is_scalar and point_is_scalar:
+            return vel.squeeze()  # (2,)
+        elif time_is_scalar:
+            return vel[0]  # (n_points, 2)
+        elif point_is_scalar:
+            return vel[:, 0]  # (n_times, 2)
+        return vel  # (n_times, n_points, 2)
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """
@@ -223,9 +259,9 @@ class StokesWave(WaveModel):
 
     def velocity_potential(
         self,
-        x: float | list[float],
-        z: float | list[float],
-        t: float = 0,
+        x: float | list[float] | NDArray,
+        z: float | list[float] | NDArray,
+        t: float | list[float] | NDArray = 0.0,
     ):
         """
         Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
@@ -238,10 +274,14 @@ class StokesWave(WaveModel):
         (``depth=-1``) an effective depth of 50π/k is used internally; z should
         be supplied in the same coordinate system (z=0 at the effective sea floor).
         """
-        if isinstance(x, (float, int)):
+        x_was_scalar = isinstance(x, (float, int))
+        t_was_scalar = isinstance(t, (float, int))
+
+        if x_was_scalar:
             x, z = [x], [z]
-        x = np.asarray(x, dtype=float)
-        z = np.asarray(z, dtype=float)
+        x = np.atleast_1d(np.asarray(x, dtype=float))  # (M,)
+        z = np.atleast_1d(np.asarray(z, dtype=float))  # (M,)
+        t = np.atleast_1d(np.asarray(t, dtype=float))  # (T,)
 
         if self.depth < 0:
             depth = 50 * pi / self.k
@@ -251,19 +291,24 @@ class StokesWave(WaveModel):
         k = self.k
         eps = k * self.height / 2
         D = self.data
-        x2 = x - self.c * t
+        c = self.c
         scale = D["C0"] * sqrt(self.g / k**3)
 
-        phi = np.zeros(x.size, float)
+        # x2 shape: (T, M) — broadcast for all (t, x) combinations
+        x2 = x[np.newaxis, :] - c * t[:, np.newaxis]
+
+        phi = np.zeros((t.size, x.size), float)
 
         def add_term(i, j):
             Aij = D.get("A%d%d" % (i, j), 0.0)
             if Aij == 0.0:
                 return
-            # Stokes A_ij contains 1/sinh(j k d) factors that prevent overflow
-            # of cosh(j k z) for normal finite depths (kd <= 50 pi). The
-            # zero-check avoids 0 * inf = nan for deep-water high harmonics.
-            phi[:] += pow(eps, i) * Aij * np.cosh(j * k * z) * np.sin(j * k * x2)
+            phi[:] += (
+                pow(eps, i)
+                * Aij
+                * np.cosh(j * k * z[np.newaxis, :])  # (1, M)
+                * np.sin(j * k * x2)                  # (T, M)
+            )
 
         add_term(1, 1)
         add_term(2, 2)
@@ -275,8 +320,13 @@ class StokesWave(WaveModel):
         add_term(5, 3)
         add_term(5, 5)
 
-        phi *= scale
-        return phi
+        phi *= scale  # (T, M)
+
+        if t_was_scalar:
+            return phi[0]  # (M,)
+        elif x_was_scalar:
+            return phi[:, 0]  # (T,)
+        return phi  # (T, M)
 
 
 def sech(x):

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -64,6 +64,9 @@ class StokesWave(WaveModel):
         if self.air is not None:
             self.air.set_wave(self)
 
+        from .cpp import StokesCppGenerator
+        self.cpp = StokesCppGenerator(self)
+
     def set_data(self, data):
         """
         Update the coefficients defining this Stokes wave

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -51,7 +51,7 @@ class StokesWave(WaveModel):
             self.order = 1
         elif N > 5:
             self.warnings = "Stokes order is maximum 5, using order 5"
-            self.order = 4
+            self.order = 5
 
         # Find the coeffients through explicit formulas
         self.k = 2 * pi / length  # The wave number

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .base_classes import WaveModel
-from .common import NonConvergenceError, RaschiiError
+from .common import NonConvergenceError, RaschiiError, blend_air_and_wave_velocities
 
 
 class StokesWave(WaveModel):
@@ -65,6 +65,7 @@ class StokesWave(WaveModel):
             self.air.set_wave(self)
 
         from .cpp import StokesCppGenerator
+
         self.cpp = StokesCppGenerator(self)
 
     def set_data(self, data):
@@ -120,6 +121,7 @@ class StokesWave(WaveModel):
     def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
+        x_1d, z_1d, t_1d = x, z, t  # save (N,), (N,), (T,) before reshaping
         x = x[np.newaxis, :]  # (1, N)
         z = z[np.newaxis, :]  # (1, N)
         t = t[:, np.newaxis]  # (T, 1)
@@ -179,8 +181,10 @@ class StokesWave(WaveModel):
         scale = self.data["C0"] * sqrt(self.g / self.k**3)
         vel = np.stack([vel_x * scale, vel_z * scale], axis=-1)  # (T, N, 2)
         if not all_points_wet:
-            # blend_air_and_wave_velocities needs updating for new shape convention
-            pass
+            for i, ti in enumerate(t_1d):
+                blend_air_and_wave_velocities(
+                    x_1d, z_1d, float(ti), self, self.air, vel[i], self.eta_eps
+                )
         return vel
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):

--- a/raschii/stokes.py
+++ b/raschii/stokes.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from .base_classes import WaveModel
-from .common import NonConvergenceError, RaschiiError, blend_air_and_wave_velocities
+from .common import NonConvergenceError, RaschiiError
 
 
 class StokesWave(WaveModel):
@@ -88,24 +88,8 @@ class StokesWave(WaveModel):
         self.T = self.length / self.c  # Wave period
         self.omega = self.c * self.k  # Wave frequency
 
-    def surface_elevation(
-        self,
-        x: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        include_depth: bool = True,
-    ):
-        """
-        Compute the surface elavation at time t for position(s) x
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        x = np.atleast_1d(np.asarray(x, dtype=float))  # (N,)
-        t = np.atleast_1d(np.asarray(t, dtype=float))  # (T,)
-
-        # x2 shape: (T, N) — broadcast for all (t, x) combinations
-        x2 = x[np.newaxis, :] - self.c * t[:, np.newaxis]
-
+    def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
+        x2 = x[np.newaxis, :] - self.c * t[:, np.newaxis]  # (T, N)
         k = self.k
         eps = k * self.height / 2
         D = self.data
@@ -122,51 +106,21 @@ class StokesWave(WaveModel):
                 + D["B55"] * cos(5 * k * x2)
             )
         ) / k
-        # eta shape: (T, N)
-
         if include_depth:
             if self.depth < 0:
                 raise RaschiiError("Cannot include depth in elevation for infinite depth")
             offset = self.depth
         else:
             offset = 0.0
+        return offset + eta
 
-        result = offset + eta
-
-        if t_was_scalar:
-            return result[0]   # (N,)
-        elif x_was_scalar:
-            return result[:, 0]  # (T,)
-        return result  # (T, N)
-
-    def velocity(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-        all_points_wet: bool = False,
-    ):
-        """
-        Compute the fluid velocity at time t for position(s) (x, z)
-        where z is 0 at the bottom and equal to depth at the free surface
-        """
+    def _velocity(self, x: NDArray, z: NDArray, t: NDArray, all_points_wet: bool) -> NDArray:
         if self.depth < 0:
             raise RaschiiError("Cannot currently compute velocity for infinite depth waves")
-
-        time_is_scalar = np.asarray(t).ndim == 0
-        point_is_scalar = np.asarray(x).ndim == 0 and np.asarray(z).ndim == 0
-
-        x = np.atleast_1d(np.asarray(x, dtype=float))
-        z = np.atleast_1d(np.asarray(z, dtype=float))
-        t = np.atleast_1d(np.asarray(t, dtype=float))
-
-        x, z = np.broadcast_arrays(x, z)
-
-        x = x[np.newaxis, :]  # (1, n_points)
-        z = z[np.newaxis, :]  # (1, n_points)
-        t = t[:, np.newaxis]  # (n_times, 1)
-
-        x2 = x - self.c * t  # (n_times, n_points)
+        x = x[np.newaxis, :]  # (1, N)
+        z = z[np.newaxis, :]  # (1, N)
+        t = t[:, np.newaxis]  # (T, 1)
+        x2 = x - self.c * t  # (T, N)
 
         def my_cosh_cos(i, j):
             n = "A%d%d" % (i, j)
@@ -220,19 +174,11 @@ class StokesWave(WaveModel):
             + my_sinh_sin(5, 5)
         )
         scale = self.data["C0"] * sqrt(self.g / self.k**3)
-        vel = np.stack([vel_x * scale, vel_z * scale], axis=-1)  # (n_times, n_points, 2)
-
+        vel = np.stack([vel_x * scale, vel_z * scale], axis=-1)  # (T, N, 2)
         if not all_points_wet:
             # blend_air_and_wave_velocities needs updating for new shape convention
             pass
-
-        if time_is_scalar and point_is_scalar:
-            return vel.squeeze()  # (2,)
-        elif time_is_scalar:
-            return vel[0]  # (n_points, 2)
-        elif point_is_scalar:
-            return vel[:, 0]  # (n_times, 2)
-        return vel  # (n_times, n_points, 2)
+        return vel
 
     def write_swd(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """
@@ -257,58 +203,24 @@ class StokesWave(WaveModel):
 
         SwdWriterStokes(self).write(path, dt, tmax=tmax, nperiods=nperiods, amp=amp)
 
-    def velocity_potential(
-        self,
-        x: float | list[float] | NDArray,
-        z: float | list[float] | NDArray,
-        t: float | list[float] | NDArray = 0.0,
-    ):
-        """
-        Compute the earth-frame velocity potential φ at time t for position(s) (x, z).
-
-        z is measured from the sea floor (z=0 at bottom, z≈depth at calm surface).
-        The gradient ∇φ equals the oscillatory fluid velocity as returned by
-        :meth:`velocity`; the constant phase-speed term is excluded.
-
-        Works for both finite and infinite depth.  For infinite-depth waves
-        (``depth=-1``) an effective depth of 50π/k is used internally; z should
-        be supplied in the same coordinate system (z=0 at the effective sea floor).
-        """
-        x_was_scalar = isinstance(x, (float, int))
-        t_was_scalar = isinstance(t, (float, int))
-
-        if x_was_scalar:
-            x, z = [x], [z]
-        x = np.atleast_1d(np.asarray(x, dtype=float))  # (M,)
-        z = np.atleast_1d(np.asarray(z, dtype=float))  # (M,)
-        t = np.atleast_1d(np.asarray(t, dtype=float))  # (T,)
-
+    def _velocity_potential(self, x: NDArray, z: NDArray, t: NDArray) -> NDArray:
         if self.depth < 0:
             depth = 50 * pi / self.k
         else:
             depth = min(self.depth, 50 * pi / self.k)
-
         k = self.k
         eps = k * self.height / 2
         D = self.data
         c = self.c
         scale = D["C0"] * sqrt(self.g / k**3)
-
-        # x2 shape: (T, M) — broadcast for all (t, x) combinations
-        x2 = x[np.newaxis, :] - c * t[:, np.newaxis]
-
+        x2 = x[np.newaxis, :] - c * t[:, np.newaxis]  # (T, M)
         phi = np.zeros((t.size, x.size), float)
 
         def add_term(i, j):
             Aij = D.get("A%d%d" % (i, j), 0.0)
             if Aij == 0.0:
                 return
-            phi[:] += (
-                pow(eps, i)
-                * Aij
-                * np.cosh(j * k * z[np.newaxis, :])  # (1, M)
-                * np.sin(j * k * x2)                  # (T, M)
-            )
+            phi[:] += pow(eps, i) * Aij * np.cosh(j * k * z[np.newaxis, :]) * np.sin(j * k * x2)
 
         add_term(1, 1)
         add_term(2, 2)
@@ -319,14 +231,7 @@ class StokesWave(WaveModel):
         add_term(5, 1)
         add_term(5, 3)
         add_term(5, 5)
-
-        phi *= scale  # (T, M)
-
-        if t_was_scalar:
-            return phi[0]  # (M,)
-        elif x_was_scalar:
-            return phi[:, 0]  # (T,)
-        return phi  # (T, M)
+        return phi * scale  # (T, M)
 
 
 def sech(x):

--- a/raschii/swd/base.py
+++ b/raschii/swd/base.py
@@ -1,7 +1,8 @@
 import numpy as np
 
+from raschii import RaschiiError, WaveModel
+
 from .swd_file import SwdShape1and2
-from raschii.common import RaschiiError
 
 
 class SwdWriter:
@@ -14,8 +15,8 @@ class SwdWriter:
     ``surface_elevation``.
     """
 
-    def __init__(self, wave):
-        self.wave = wave
+    def __init__(self, wave: WaveModel):
+        self.wave: WaveModel = wave
 
     def write(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """
@@ -44,7 +45,7 @@ class SwdWriter:
         if tmax is None:
             if nperiods is None:
                 raise RaschiiError("Either tmax or nperiods must be given")
-            tmax = nperiods * wave.T
+            tmax = nperiods * wave.period
         if not (tmax > dt > 0.0):
             raise RaschiiError(f"Must have tmax > dt > 0, got tmax={tmax!r}, dt={dt!r}")
 
@@ -71,7 +72,7 @@ class SwdWriter:
             vcs = np.zeros(nc, complex)  # not written, but SwdShape1and2 requires same length
 
         swd = SwdShape1and2(
-            wave.T,
+            wave.period,
             wave.length,
             wave.depth,
             vcs,

--- a/raschii/swd/swd_airy.py
+++ b/raschii/swd/swd_airy.py
@@ -10,7 +10,7 @@ class SwdWriterAiry:
     """
 
     def __init__(self, wave):
-        from raschii.stokes import StokesWave
+        from raschii.wave_stokes import StokesWave
 
         # Build a Stokes N=1 wave from the Airy parameters.
         # The air model does not affect SWD output.

--- a/raschii/swd/swd_fenton.py
+++ b/raschii/swd/swd_fenton.py
@@ -2,11 +2,15 @@ import numpy as np
 from numpy import array, empty
 from numpy.fft import irfft
 
+from ..wave_fenton import FentonWave
 from .base import SwdWriter
 
 
 class SwdWriterFenton(SwdWriter):
     """SWD writer for Fenton stream-function waves."""
+
+    # The wave model set in the base-class constructor must be a FentonWave
+    wave: FentonWave
 
     def _effective_depth(self) -> float:
         wave = self.wave
@@ -51,7 +55,7 @@ class SwdWriterFenton(SwdWriter):
         wave = self.wave
         return {
             "model": "Fenton",
-            "T": wave.T,
+            "T": wave.period,
             "height": wave.height,
             "depth": wave.depth,
             "depth_actual": depth,

--- a/raschii/swd/swd_file.py
+++ b/raschii/swd/swd_file.py
@@ -1,7 +1,9 @@
+import json
 from datetime import datetime
 from struct import pack, unpack
 
 import numpy as np
+from numpy.typing import NDArray
 
 from raschii import version as raschii_version
 
@@ -12,9 +14,9 @@ class SwdShape1and2:
         t_wave: float,
         length: float,
         depth: float,
-        c_cofs: list[complex],
-        h_cofs: list[complex],
-        input_data: str,
+        c_cofs: list[complex] | NDArray,
+        h_cofs: list[complex] | NDArray,
+        input_data: dict,
         g: float = 9.81,
         order_zpos: int = -1,
     ):
@@ -61,7 +63,7 @@ class SwdShape1and2:
         self.h_cofs = h_cofs
         self.g = g
         self.lscale = 1.0
-        self.input_data = str(input_data).encode("utf-8")
+        self.input_data = json.dumps(input_data).encode("utf-8")
 
     def write(self, path, dt, tmax=None, nperiods=None, amp: int = 1):
         """

--- a/raschii/swd/swd_stokes.py
+++ b/raschii/swd/swd_stokes.py
@@ -2,11 +2,15 @@ from math import pi, sqrt
 
 import numpy as np
 
+from ..wave_stokes import StokesWave
 from .base import SwdWriter
 
 
 class SwdWriterStokes(SwdWriter):
     """SWD writer for Stokes waves."""
+
+    # The wave model set in the base-class constructor must be a StokesWave
+    wave: StokesWave
 
     def _effective_depth(self) -> float:
         wave = self.wave
@@ -66,7 +70,7 @@ class SwdWriterStokes(SwdWriter):
         wave = self.wave
         return {
             "model": "Stokes",
-            "T": wave.T,
+            "T": wave.period,
             "length": wave.length,
             "height": wave.height,
             "depth": wave.depth,

--- a/raschii/wave_airy.py
+++ b/raschii/wave_airy.py
@@ -10,7 +10,7 @@ from numpy import (
 )
 from numpy.typing import NDArray
 
-from .base_classes import WaveModel, AirPhaseModel
+from .base_classes import AirPhaseModel, WaveModel
 from .common import (
     NonConvergenceError,
     RaschiiError,
@@ -72,7 +72,7 @@ class AiryWave(WaveModel):
         else:
             # Finite depth
             self.omega = (self.k * g * tanh(self.k * depth)) ** 0.5
-        
+
         #: Wave celerity (phase speed)
         self.c = self.omega / self.k
 

--- a/raschii/wave_airy.py
+++ b/raschii/wave_airy.py
@@ -72,8 +72,12 @@ class AiryWave(WaveModel):
         else:
             # Finite depth
             self.omega = (self.k * g * tanh(self.k * depth)) ** 0.5
+        
+        #: Wave celerity (phase speed)
         self.c = self.omega / self.k
-        self.T = self.length / self.c  # Wave period
+
+        #: Wave period
+        self.period = self.length / self.c
 
         # For evaluating velocities close to the free surface
         self.eta_eps = self.height / 1e5

--- a/raschii/wave_fenton.py
+++ b/raschii/wave_fenton.py
@@ -133,9 +133,6 @@ class FentonWave(WaveModel):
         #: Wave celerity (phase speed) in [m/s]
         self.c = data["c"]
 
-        # Mean Stokes drift speed in [m/s]. TODO: verify this ...
-        self.cs = self.c - data["Q"]
-
         #: Wave period in [s]
         self.period = self.length / self.c
 
@@ -147,6 +144,9 @@ class FentonWave(WaveModel):
         self.E = zeros(N + 1, float)
         J = arange(0, N + 1)
         self.E = trapezoid_integration(self.eta * cos(J * J[:, newaxis] * pi / N))
+
+        #: The value *Q* from the Fenton stream-function wave
+        self.Q = data["Q"]
 
     def stream_function(self, x, z, t=0, frame=Frame.EARTH):
         """

--- a/raschii/wave_fenton.py
+++ b/raschii/wave_fenton.py
@@ -120,13 +120,27 @@ class FentonWave(WaveModel):
         Update the coefficients defining this stream-function wave
         """
         self.data = data
-        self.eta = data["eta"]  # Wave elevation at colocation points
-        self.x = data["x"]  # Positions of colocation points
-        self.k = data["k"]  # Wave number
-        self.c = data["c"]  # Phase speed
-        self.cs = self.c - data["Q"]  # Mean Stokes drift speed
-        self.T = self.length / self.c  # Wave period
-        self.omega = self.c * self.k  # Wave frequency
+
+        #: Wave elevation at colocation points
+        self.eta = data["eta"]
+
+        #: Positions of colocation points
+        self.x = data["x"]
+
+        #: Wave number (2 pi / wavelength) in [1/m]
+        self.k = data["k"]
+
+        #: Wave celerity (phase speed) in [m/s]
+        self.c = data["c"]
+
+        # Mean Stokes drift speed in [m/s]. TODO: verify this ...
+        self.cs = self.c - data["Q"]
+
+        #: Wave period in [s]
+        self.period = self.length / self.c
+
+        #: Wave frequency in [rad/s]
+        self.omega = self.c * self.k
 
         # Cosine series coefficients for the elevation
         N = len(self.eta) - 1
@@ -612,7 +626,7 @@ def compute_length_from_period(
     This would be much faster if we had an implementation of the Fenton wave
     theory dispersion relation for arbitrary order N
     """
-    from .airy import compute_length_from_period as airy_compute_length_from_period
+    from .wave_airy import compute_length_from_period as airy_compute_length_from_period
 
     # Initial guess is based on the linear dispersion relation for deep water waves
     length = airy_compute_length_from_period(depth=depth, period=period, g=g)
@@ -628,14 +642,14 @@ def compute_length_from_period(
         length = length_N
 
         # New guess for the wave length by interpolation
-        f = (period - wave1.T) / (wave2.T - wave1.T)
+        f = (period - wave1.period) / (wave2.period - wave1.period)
         length_N = wave1.length + (wave2.length - wave1.length) * f
 
         # Resulting wave period for the new length from the dispersion relation
         waveN = FentonWave(height=height, depth=depth, length=length_N, N=N, g=g, relax=relax)
 
         # Update the two points used for the interpolation in the next iteration
-        if waveN.T < period:
+        if waveN.period < period:
             wave1 = waveN
         else:
             wave2 = waveN

--- a/raschii/wave_stokes.py
+++ b/raschii/wave_stokes.py
@@ -99,21 +99,21 @@ class StokesWave(WaveModel):
         d = min(d, 50 * pi / self.k)
 
         c = (data["C0"] + pow(eps, 2) * data["C2"] + pow(eps, 4) * data["C4"]) * sqrt(self.g / k)
-        Q = (c * d * sqrt(k**3 / self.g) + data["D2"] * eps**2 + data["D4"] * eps**4) * sqrt(
-            self.g / k**3
-        )
 
         #: Wave celerity (phase speed) in [m/s]
         self.c = c
-
-        # Mean Stokes drift speed in [m/s]. TODO: verify this ...
-        self.cs = c - Q
 
         #: Wave period in [s]
         self.period = self.length / self.c
 
         #: Wave frequency in [rad/s]
         self.omega = self.c * self.k
+
+        # The same (??) Q as the one in for the Fenton stream-function wave
+        Q = (c * d * sqrt(k**3 / self.g) + data["D2"] * eps**2 + data["D4"] * eps**4) * sqrt(
+            self.g / k**3
+        )
+        self.Q: float = Q
 
     def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         x2 = x[np.newaxis, :] - self.c * t[:, np.newaxis]  # (T, N)

--- a/raschii/wave_stokes.py
+++ b/raschii/wave_stokes.py
@@ -3,7 +3,7 @@ from math import exp, pi, pow, sinh, sqrt, tanh
 import numpy as np
 from numpy.typing import NDArray
 
-from .base_classes import WaveModel, AirPhaseModel
+from .base_classes import AirPhaseModel, WaveModel
 from .common import NonConvergenceError, RaschiiError, blend_air_and_wave_velocities
 
 
@@ -103,10 +103,17 @@ class StokesWave(WaveModel):
             self.g / k**3
         )
 
-        self.c = c  # Phase speed
-        self.cs = c - Q  # Mean Stokes drift speed (TODO: verify this!)
-        self.T = self.length / self.c  # Wave period
-        self.omega = self.c * self.k  # Wave frequency
+        #: Wave celerity (phase speed) in [m/s]
+        self.c = c
+
+        # Mean Stokes drift speed in [m/s]. TODO: verify this ...
+        self.cs = c - Q
+
+        #: Wave period in [s]
+        self.period = self.length / self.c
+
+        #: Wave frequency in [rad/s]
+        self.omega = self.c * self.k
 
     def _surface_elevation(self, x: NDArray, t: NDArray, include_depth: bool) -> NDArray:
         x2 = x[np.newaxis, :] - self.c * t[:, np.newaxis]  # (T, N)
@@ -443,7 +450,7 @@ def compute_length_from_period(
     This would be much faster if we had an implementation of the Stokes wave
     theory dispersion relation, which should be not too hard to implement ...
     """
-    from .airy import compute_length_from_period as airy_compute_length_from_period
+    from .wave_airy import compute_length_from_period as airy_compute_length_from_period
 
     # Initial guess is based on the linear dispersion relation for deep water waves
     length = airy_compute_length_from_period(depth=depth, period=period, g=g)
@@ -459,14 +466,14 @@ def compute_length_from_period(
         length = length_N
 
         # New guess for the wave length by interpolation
-        f = (period - wave1.T) / (wave2.T - wave1.T)
+        f = (period - wave1.period) / (wave2.period - wave1.period)
         length_N = wave1.length + (wave2.length - wave1.length) * f
 
         # Resulting wave period for the new length from the dispersion relation
         waveN = StokesWave(height=height, depth=depth, length=length_N, N=N, g=g)
 
         # Update the two points used for the interpolation in the next iteration
-        if waveN.T < period:
+        if waveN.period < period:
             wave1 = waveN
         else:
             wave2 = waveN

--- a/tests/test_air_fenton.py
+++ b/tests/test_air_fenton.py
@@ -48,9 +48,9 @@ def test_fenton_air_with_fenton(wave_with_air_model):
 
     # Compare velocities with numerical differentiation of the stream function
     avel = air.velocity(xr, zr, time)
-    sf0 = air.stream_function(xr, zr, time, frame="c")
-    sfX = air.stream_function(xr + eps, zr, time, frame="c")
-    sfZ = air.stream_function(xr, zr + eps, time, frame="c")
+    sf0 = air.stream_function(xr, zr, time, frame="WAVE")
+    sfX = air.stream_function(xr + eps, zr, time, frame="WAVE")
+    sfZ = air.stream_function(xr, zr + eps, time, frame="WAVE")
     sfvel_x = (sfZ - sf0) / eps
     sfvel_z = -(sfX - sf0) / eps
     err = abs(avel[:, 0] - sfvel_x) + abs(avel[:, 1] - sfvel_z)

--- a/tests/test_air_fenton.py
+++ b/tests/test_air_fenton.py
@@ -132,7 +132,7 @@ def test_fenton_air_with_fenton_cpp_divergence(tmpdir, wave_with_air_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cppx, cppz = fwave.velocity_cpp()
+    cppx, cppz = fwave.cpp.velocity()
 
     cpp = (
         cpp_wrapper.replace("CODE_X_GOES_HERE", cppx)

--- a/tests/test_air_fenton.py
+++ b/tests/test_air_fenton.py
@@ -26,7 +26,7 @@ def wave_with_air_model(request):
     from raschii import FentonAirPhase, FentonWave
 
     air = FentonAirPhase(height_air, blending_height)
-    fwave = FentonWave(height, depth, length, N, air=air)
+    fwave = FentonWave(height, depth, length, N=N, air=air)
     return fwave, air, time, plot
 
 

--- a/tests/test_blending.py
+++ b/tests/test_blending.py
@@ -1,0 +1,107 @@
+"""
+Pure-Python tests for the velocity blending behaviour (no C++ compiler needed).
+
+These tests catch regressions where blend_air_and_wave_velocities is accidentally
+disabled in the _velocity implementations.
+"""
+import numpy
+import pytest
+from raschii import FentonAirPhase, FentonWave, get_wave_model
+
+
+@pytest.fixture(params=["Airy", "Fenton"])
+def wave_no_air(request):
+    WaveClass = get_wave_model(request.param)[0]
+    if request.param == "Airy":
+        return WaveClass(height=1.0, depth=10.0, length=20.0)
+    else:
+        return WaveClass(height=1.0, depth=10.0, length=20.0, N=5)
+
+
+def test_velocity_above_surface_is_zero(wave_no_air):
+    """
+    Without an air model, velocity must be zero above the free surface when
+    all_points_wet=False (the default). This is the Python-side regression
+    test for blend_air_and_wave_velocities being active.
+    """
+    wave = wave_no_air
+    x = wave.length / 4
+
+    # A point well above the highest possible surface elevation
+    z_above = wave.depth + wave.height * 5
+
+    vel = wave.velocity(x, z_above)  # all_points_wet defaults to False
+    assert vel[0] == 0.0, f"Expected u=0 above surface, got {vel[0]}"
+    assert vel[1] == 0.0, f"Expected w=0 above surface, got {vel[1]}"
+
+
+def test_velocity_above_surface_nonzero_when_all_wet(wave_no_air):
+    """
+    With all_points_wet=True the blending is skipped and velocity above the
+    surface should be non-zero (it returns the raw wave-theory value).
+    """
+    wave = wave_no_air
+    x = wave.length / 4
+    z_above = wave.depth + wave.height * 5
+
+    vel = wave.velocity(x, z_above, all_points_wet=True)
+    assert abs(vel[0]) > 0 or abs(vel[1]) > 0, "Expected non-zero velocity with all_points_wet=True"
+
+
+def test_velocity_array_above_surface_is_zero(wave_no_air):
+    """Same as above but with array inputs (exercises the T=1 loop path)."""
+    wave = wave_no_air
+    x = numpy.linspace(0, wave.length, 20)
+    z = numpy.full_like(x, wave.depth + wave.height * 5)
+
+    vel = wave.velocity(x, z)  # (N, 2)
+    assert numpy.all(vel[:, 0] == 0.0), "Expected all u=0 above surface"
+    assert numpy.all(vel[:, 1] == 0.0), "Expected all w=0 above surface"
+
+
+def test_blended_velocity_divergence_free():
+    """
+    The Python blended velocity field (with FentonAir) must be divergence-free.
+    This is the pure-Python equivalent of test_fenton_air_with_fenton_cpp_divergence.
+    """
+    air = FentonAirPhase(height=100.0)
+    fwave = FentonWave(height=10.0, depth=200.0, length=100.0, N=5, air=air)
+
+    length, depth, height = fwave.length, fwave.depth, fwave.height
+    time = 1.0
+    eps = 1e-7
+
+    top = depth + 2.75 * height
+    xpos = numpy.linspace(-length / 2, length / 2, 51)
+    zpos = numpy.linspace(depth - height / 2, top, 51)
+    X, Z = numpy.meshgrid(xpos, zpos)
+    xr, zr = X.ravel(), Z.ravel()
+
+    totvel = fwave.velocity(xr, zr, time)
+    velsdx = fwave.velocity(xr + eps, zr, time)
+    velsdz = fwave.velocity(xr, zr + eps, time)
+    div = (velsdx[:, 0] - totvel[:, 0] + velsdz[:, 1] - totvel[:, 1]) / eps
+
+    max_abs_div = abs(div).max()
+    assert max_abs_div < 1e-4, f"Blended velocity field not divergence-free: max |div| = {max_abs_div}"
+
+
+def test_blended_velocity_matches_zero_above_blend_zone():
+    """
+    With FentonAir, velocity well above the blending zone equals the air velocity
+    (not the raw wave velocity). This checks the blending actually switches over.
+    """
+    blending_height = 20.0
+    air = FentonAirPhase(height=100.0, blending_height=blending_height)
+    fwave = FentonWave(height=10.0, depth=200.0, length=100.0, N=5, air=air)
+
+    x = 0.0
+    # Point well above the blending zone
+    z_far_above = fwave.depth + blending_height * 2
+
+    vel_blended = fwave.velocity(x, z_far_above)
+    vel_raw_wave = fwave.velocity(x, z_far_above, all_points_wet=True)
+
+    # The blended value should differ significantly from the raw wave value
+    assert abs(vel_blended[0] - vel_raw_wave[0]) > 0.01 or abs(vel_blended[1] - vel_raw_wave[1]) > 0.01, \
+        "Blended velocity above blend zone should differ from raw wave velocity"

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,0 +1,125 @@
+"""
+Integration tests for the raschii command line interface.
+
+These tests run the CLI tools in a subprocess using the same Python
+interpreter that is running the test suite, so no path juggling is needed.
+Plot tests are skipped when matplotlib is not installed; install
+``raschii[plot]`` to run them.
+"""
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run(*args):
+    """Run a command as a subprocess and return CompletedProcess."""
+    return subprocess.run(
+        [sys.executable, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+try:
+    import matplotlib  # noqa: F401
+
+    has_matplotlib = True
+except ImportError:
+    has_matplotlib = False
+
+skip_no_matplotlib = pytest.mark.skipif(
+    not has_matplotlib,
+    reason="matplotlib not installed — pip install raschii[plot] to run plot tests",
+)
+
+
+# ---------------------------------------------------------------------------
+# raschii.cmd.swd  (no matplotlib dependency)
+# ---------------------------------------------------------------------------
+
+
+def test_swd_cmd_by_length(tmp_path):
+    """SWD writer: positional wave_length argument."""
+    swd = str(tmp_path / "wave.swd")
+    result = _run("-m", "raschii.cmd.swd", "-N", "5", swd, "Fenton", "0.2", "1.5", "2.0")
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(swd), "SWD file was not created"
+
+
+def test_swd_cmd_by_period(tmp_path):
+    """SWD writer: --period flag instead of positional wave_length."""
+    swd = str(tmp_path / "wave.swd")
+    result = _run(
+        "-m", "raschii.cmd.swd", "-N", "5", "--period", "1.2",
+        swd, "Fenton", "0.2", "1.5",
+    )
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(swd), "SWD file was not created"
+
+
+def test_swd_cmd_stokes(tmp_path):
+    """SWD writer: Stokes wave model."""
+    swd = str(tmp_path / "stokes.swd")
+    result = _run("-m", "raschii.cmd.swd", "-N", "3", swd, "Stokes", "0.2", "1.5", "2.0")
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(swd)
+
+
+def test_swd_cmd_missing_length_and_period(tmp_path):
+    """SWD writer: exits non-zero when neither wave_length nor --period is given."""
+    swd = str(tmp_path / "wave.swd")
+    result = _run("-m", "raschii.cmd.swd", swd, "Fenton", "0.2", "1.5")
+    assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# raschii.cmd.plot  (require matplotlib)
+# ---------------------------------------------------------------------------
+
+
+@skip_no_matplotlib
+def test_plot_cmd_saves_png_by_length(tmp_path):
+    """Plot command saves PNG files when --output-prefix is given (wave_length)."""
+    prefix = str(tmp_path / "plot")
+    result = _run(
+        "-m", "raschii.cmd.plot", "-N", "5",
+        "--output-prefix", prefix,
+        "Fenton", "0.2", "1.5", "2.0",
+    )
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(prefix + "_elevation.png"), "Elevation PNG not created"
+    assert os.path.isfile(prefix + "_velocities.png"), "Velocities PNG not created"
+
+
+@skip_no_matplotlib
+def test_plot_cmd_saves_png_by_period(tmp_path):
+    """Plot command saves PNG files when --period is used instead of wave_length."""
+    prefix = str(tmp_path / "plot_period")
+    result = _run(
+        "-m", "raschii.cmd.plot", "-N", "5",
+        "--period", "1.2", "--output-prefix", prefix,
+        "Fenton", "0.2", "1.5",
+    )
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(prefix + "_elevation.png")
+    assert os.path.isfile(prefix + "_velocities.png")
+
+
+@skip_no_matplotlib
+def test_plot_cmd_multiple_models(tmp_path):
+    """Plot command handles a comma-separated list of wave models."""
+    prefix = str(tmp_path / "multi")
+    result = _run(
+        "-m", "raschii.cmd.plot", "-N", "5",
+        "--output-prefix", prefix,
+        "Fenton,Stokes", "0.2", "1.5", "2.0",
+    )
+    assert result.returncode == 0, f"Command failed:\n{result.stderr}"
+    assert os.path.isfile(prefix + "_elevation.png")
+    assert os.path.isfile(prefix + "_velocities.png")

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -203,7 +203,11 @@ def test_cpp_vs_py_stream_function(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.cpp.stream_function(frame="WAVE")
+    try:
+        cpp = wave_model.cpp.stream_function(frame="WAVE")
+    except NotImplementedError:
+        classname = wave_model.__class__.__name__
+        raise pytest.xfail(f"Missing {classname}CppGenerator.stream_function method")
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp).replace("x[2]", "x[1]")
     mod = jit_compile(cpp, cache_dir)
 
@@ -247,7 +251,11 @@ def test_cpp_vs_py_slope(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.cpp.slope()
+    try:
+        cpp = wave_model.cpp.slope()
+    except NotImplementedError:
+        classname = wave_model.__class__.__name__
+        raise pytest.xfail(f"Missing {classname}CppGenerator.slope method")
     assert "x[2]" not in cpp
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp)
     mod = jit_compile(cpp, cache_dir)

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -203,7 +203,7 @@ def test_cpp_vs_py_stream_function(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.cpp.stream_function(frame="c")
+    cpp = wave_model.cpp.stream_function(frame="WAVE")
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp).replace("x[2]", "x[1]")
     mod = jit_compile(cpp, cache_dir)
 
@@ -215,7 +215,7 @@ def test_cpp_vs_py_stream_function(tmpdir, wave_model):
     sf_cpp = numpy.zeros_like(xr)
     for i in range(xr.size):
         sf_cpp[i] = mod.sfunc([xr[i], zr[i]], t)
-    sf_py = wave_model.stream_function(xr, zr, t, frame="c")
+    sf_py = wave_model.stream_function(xr, zr, t, frame="WAVE")
 
     # Check the results
     test_name = "%s C++ stream function" % wave_model.__class__.__name__
@@ -271,7 +271,7 @@ def test_cpp_elevation_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
     cpp = wave_model.cpp.elevation()
     assert "x[2]" not in cpp
-    if 'np.' in cpp or 'numpy' in cpp:
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False
 
@@ -279,22 +279,30 @@ def test_cpp_elevation_nocompile(wave_model):
 def test_cpp_velocity_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
     cpp = wave_model.cpp.velocity()
-    if 'np.' in cpp or 'numpy' in cpp:
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False
 
 
 def test_cpp_stream_function_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.cpp.stream_function()
-    if 'np.' in cpp or 'numpy' in cpp:
+    try:
+        cpp = wave_model.cpp.stream_function()
+    except NotImplementedError:
+        classname = wave_model.__class__.__name__
+        raise pytest.xfail(f"Missing {classname}CppGenerator.stream_function method")
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False
 
 
 def test_cpp_slope_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.cpp.slope()
-    if 'np.' in cpp or 'numpy' in cpp:
+    try:
+        cpp = wave_model.cpp.slope()
+    except NotImplementedError:
+        classname = wave_model.__class__.__name__
+        raise pytest.xfail(f"Missing {classname}CppGenerator.slope method")
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -15,13 +15,13 @@ def wave_model(request):
         model = get_wave_model("Fenton")[0](height=1, depth=10, length=20, N=5)
 
     for tname, mname in [
-        ("elevation", "elevation_cpp"),
-        ("velocity", "velocity_cpp"),
-        ("stream_function", "stream_function_cpp"),
-        ("slope", "slope_cpp"),
+        ("elevation", "elevation"),
+        ("velocity", "velocity"),
+        ("stream_function", "stream_function"),
+        ("slope", "slope"),
     ]:
-        if tname in request.node.name and not hasattr(model, mname):
-            pytest.xfail("Missing %sWave.%s method" % (request.param, mname))
+        if tname in request.node.name and not hasattr(model.cpp, mname):
+            pytest.xfail("Missing %sCppGenerator.%s method" % (request.param, mname))
 
     return model
 
@@ -101,7 +101,7 @@ def test_cpp_vs_py_elevation(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.elevation_cpp()
+    cpp = wave_model.cpp.elevation()
     assert "x[2]" not in cpp
     mod = jit_compile(cpp_wrapper.replace("CODE_GOES_HERE", cpp), cache_dir)
 
@@ -151,7 +151,7 @@ def test_cpp_vs_py_velocity(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cppx, cppz = wave_model.velocity_cpp()
+    cppx, cppz = wave_model.cpp.velocity()
     cpp = (
         cpp_wrapper.replace("CODE_X_GOES_HERE", cppx)
         .replace("CODE_Z_GOES_HERE", cppz)
@@ -203,7 +203,7 @@ def test_cpp_vs_py_stream_function(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.stream_function_cpp(frame="c")
+    cpp = wave_model.cpp.stream_function(frame="c")
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp).replace("x[2]", "x[1]")
     mod = jit_compile(cpp, cache_dir)
 
@@ -247,7 +247,7 @@ def test_cpp_vs_py_slope(tmpdir, wave_model):
     cache_dir = tmpdir.ensure("jit_cache", dir=True)
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = wave_model.slope_cpp()
+    cpp = wave_model.cpp.slope()
     assert "x[2]" not in cpp
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp)
     mod = jit_compile(cpp, cache_dir)
@@ -269,7 +269,7 @@ def test_cpp_vs_py_slope(tmpdir, wave_model):
 
 def test_cpp_elevation_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.elevation_cpp()
+    cpp = wave_model.cpp.elevation()
     assert "x[2]" not in cpp
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
@@ -278,7 +278,7 @@ def test_cpp_elevation_nocompile(wave_model):
 
 def test_cpp_velocity_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.velocity_cpp()
+    cpp = wave_model.cpp.velocity()
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
         assert False
@@ -286,7 +286,7 @@ def test_cpp_velocity_nocompile(wave_model):
 
 def test_cpp_stream_function_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.stream_function_cpp()
+    cpp = wave_model.cpp.stream_function()
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
         assert False
@@ -294,7 +294,7 @@ def test_cpp_stream_function_nocompile(wave_model):
 
 def test_cpp_slope_nocompile(wave_model):
     # Check that the wave model produces valid C++ code
-    cpp = wave_model.slope_cpp()
+    cpp = wave_model.cpp.slope()
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
         assert False

--- a/tests/test_cpp_air.py
+++ b/tests/test_cpp_air.py
@@ -68,7 +68,7 @@ def test_cpp_vs_py_air_stream_function(tmpdir, air_model):
     air_model, height, depth, length = air_model
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = air_model.stream_function_cpp(frame="c")
+    cpp = air_model.cpp.stream_function(frame="c")
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp).replace("x[2]", "x[1]")
     mod = jit_compile(cpp, cache_dir)
 
@@ -119,7 +119,7 @@ def test_cpp_vs_py_air_velocity(tmpdir, air_model):
     air_model, height, depth, length = air_model
 
     # Check that the wave model produces the same results in C++ and Python
-    cppx, cppz = air_model.velocity_cpp()
+    cppx, cppz = air_model.cpp.velocity()
     cpp = (
         cpp_wrapper.replace("CODE_X_GOES_HERE", cppx)
         .replace("CODE_Z_GOES_HERE", cppz)
@@ -149,7 +149,7 @@ def test_cpp_vs_py_air_velocity(tmpdir, air_model):
 def test_cpp_air_stream_function_nocompile(air_model):
     # Check that the wave model produces valid C++ code
     air_model, height, depth, length = air_model
-    cpp = air_model.stream_function_cpp(frame="c")
+    cpp = air_model.cpp.stream_function(frame="c")
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
         assert False
@@ -158,7 +158,7 @@ def test_cpp_air_stream_function_nocompile(air_model):
 def test_cpp_air_velocity_nocompile(air_model):
     # Check that the wave model produces valid C++ code
     air_model, height, depth, length = air_model
-    cpp = air_model.velocity_cpp()
+    cpp = air_model.cpp.velocity()
     if 'np.' in cpp or 'numpy' in cpp:
         print(cpp)
         assert False

--- a/tests/test_cpp_air.py
+++ b/tests/test_cpp_air.py
@@ -68,7 +68,7 @@ def test_cpp_vs_py_air_stream_function(tmpdir, air_model):
     air_model, height, depth, length = air_model
 
     # Check that the wave model produces the same results in C++ and Python
-    cpp = air_model.cpp.stream_function(frame="c")
+    cpp = air_model.cpp.stream_function(frame="WAVE")
     cpp = cpp_wrapper.replace("CODE_GOES_HERE", cpp).replace("x[2]", "x[1]")
     mod = jit_compile(cpp, cache_dir)
 
@@ -80,7 +80,7 @@ def test_cpp_vs_py_air_stream_function(tmpdir, air_model):
     sf_cpp = numpy.zeros_like(xr)
     for i in range(xr.size):
         sf_cpp[i] = mod.sfunc([xr[i], zr[i]], t)
-    sf_py = air_model.stream_function(xr, zr, t, frame="c")
+    sf_py = air_model.stream_function(xr, zr, t, frame="WAVE")
 
     # Check the results
     test_name = "%s C++ stream function" % air_model.__class__.__name__
@@ -149,8 +149,8 @@ def test_cpp_vs_py_air_velocity(tmpdir, air_model):
 def test_cpp_air_stream_function_nocompile(air_model):
     # Check that the wave model produces valid C++ code
     air_model, height, depth, length = air_model
-    cpp = air_model.cpp.stream_function(frame="c")
-    if 'np.' in cpp or 'numpy' in cpp:
+    cpp = air_model.cpp.stream_function(frame="WAVE")
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False
 
@@ -159,6 +159,6 @@ def test_cpp_air_velocity_nocompile(air_model):
     # Check that the wave model produces valid C++ code
     air_model, height, depth, length = air_model
     cpp = air_model.cpp.velocity()
-    if 'np.' in cpp or 'numpy' in cpp:
+    if "np." in cpp or "numpy" in cpp:
         print(cpp)
         assert False

--- a/tests/test_fenton.py
+++ b/tests/test_fenton.py
@@ -234,16 +234,16 @@ def test_fenton_stream_function_and_slope():
     depth = 200.0
     length = 100.0
     N = 5
-    fwave = FentonWave(height, depth, length, N)
+    fwave = FentonWave(height, depth, length, N=N)
 
     # Compare velocities with numerical differentiation of the stream function
     eps = 1e-7
     for x in numpy.linspace(0, length, 21):
         z = depth + height / 2
         vel = fwave.velocity(x, z, all_points_wet=True)
-        sf0 = fwave.stream_function(x, z, frame="c")
-        sfX = fwave.stream_function(x + eps, z, frame="c")
-        sfZ = fwave.stream_function(x, z + eps, frame="c")
+        sf0 = fwave.stream_function(x, z, frame="WAVE")
+        sfX = fwave.stream_function(x + eps, z, frame="WAVE")
+        sfZ = fwave.stream_function(x, z + eps, frame="WAVE")
         assert vel.shape == (2,) and sf0.shape == (1,) and sfX.shape == (1,)
         sfvel_x = (sfZ[0] - sf0) / eps
         sfvel_z = -(sfX[0] - sf0) / eps

--- a/tests/test_fenton.py
+++ b/tests/test_fenton.py
@@ -36,7 +36,7 @@ def test_fenton_jacobian():
     M = array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
 
     # Compute the jacobian using the two methods
-    from raschii.fenton import fprime, fprime_num
+    from raschii.wave_fenton import fprime, fprime_num
 
     jacA = fprime(coeffs, H, k, D, J, M)
     jacN = fprime_num(coeffs, H, k, D, J, M)

--- a/tests/test_fenton.py
+++ b/tests/test_fenton.py
@@ -255,7 +255,7 @@ def test_fenton_stream_function_and_slope():
     for x in numpy.linspace(0, length, 21):
         e0 = fwave.surface_elevation(x)
         slope = fwave.surface_slope(x)
-        assert e0.shape == (1,) and slope.shape == (1,)
+        assert numpy.ndim(e0) == 0 and slope.shape == (1,)
 
         e1 = fwave.surface_elevation(x + eps)
         slope_num = (e1 - e0) / eps

--- a/tests/test_fenton.py
+++ b/tests/test_fenton.py
@@ -76,7 +76,7 @@ def test_compare_fenton_m_01():
     length = 2
     N = 30
     print(*check_breaking_criteria(height, depth, length))
-    fwave = FentonWave(height, depth, length, N)
+    fwave = FentonWave(height, depth, length, N=N)
     py_res = fwave.data
 
     ml_eta = array(

--- a/tests/test_fenton.py
+++ b/tests/test_fenton.py
@@ -244,12 +244,12 @@ def test_fenton_stream_function_and_slope():
         sf0 = fwave.stream_function(x, z, frame="c")
         sfX = fwave.stream_function(x + eps, z, frame="c")
         sfZ = fwave.stream_function(x, z + eps, frame="c")
-        assert vel.shape == (1, 2) and sf0.shape == (1,) and sfX.shape == (1,)
+        assert vel.shape == (2,) and sf0.shape == (1,) and sfX.shape == (1,)
         sfvel_x = (sfZ[0] - sf0) / eps
         sfvel_z = -(sfX[0] - sf0) / eps
         print("x: %r, z: %r, vel: %r, vel_num: %r" % (x, z, vel, (sfvel_x, sfvel_z)))
-        assert abs(vel[0, 0] - sfvel_x) < 1e-5
-        assert abs(vel[0, 1] - sfvel_z) < 1e-5
+        assert abs(vel[0] - sfvel_x) < 1e-5
+        assert abs(vel[1] - sfvel_z) < 1e-5
 
     # Compare slope with numerical differentiation of the elevation
     for x in numpy.linspace(0, length, 21):

--- a/tests/test_infinite_depth.py
+++ b/tests/test_infinite_depth.py
@@ -19,7 +19,7 @@ def test_infinite_depth_airy(give_period: bool):
     wave2 = WaveModel(depth=-1, **inp)
 
     assert abs(wave1.length - wave2.length) < 1e-4
-    assert abs(wave1.T - wave2.T) < 1e-4
+    assert abs(wave1.period - wave2.period) < 1e-4
     assert abs(wave1.c - wave2.c) < 1e-4
 
 
@@ -44,7 +44,7 @@ def test_infinite_depth_stokes(order: int, give_period: bool):
     wave2 = WaveModel(depth=-1, **inp)
 
     assert abs(wave1.length - wave2.length) < 1e-4
-    assert abs(wave1.T - wave2.T) < 1e-4
+    assert abs(wave1.period - wave2.period) < 1e-4
     assert abs(wave1.c - wave2.c) < 1e-4
 
 
@@ -69,5 +69,5 @@ def test_infinite_depth_fenton(order: int, give_period: bool):
     wave2 = WaveModel(depth=-1, **inp)
 
     assert abs(wave1.length - wave2.length) < 1e-4
-    assert abs(wave1.T - wave2.T) < 1e-4
+    assert abs(wave1.period - wave2.period) < 1e-4
     assert abs(wave1.c - wave2.c) < 1e-4

--- a/tests/test_period_instead_of_length.py
+++ b/tests/test_period_instead_of_length.py
@@ -8,7 +8,7 @@ def test_period_instead_of_length_airy():
     wave = WaveModel(height=12, depth=200, period=15)
 
     assert abs(wave.length - 350.7521) < 1e-2
-    assert abs(wave.T - 15.0) < 1e-2
+    assert abs(wave.period - 15.0) < 1e-2
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 5])
@@ -20,7 +20,7 @@ def test_period_instead_of_length_stokes(order: int):
 
     if order == 5:
         assert abs(wave.length - 354.7048) < 1e-2
-    assert abs(wave.T - 15.0) < 1e-2
+    assert abs(wave.period - 15.0) < 1e-2
 
 
 @pytest.mark.parametrize("order", [1, 2, 3, 5, 10, 20])
@@ -32,4 +32,4 @@ def test_period_instead_of_length_fenton(order: int):
 
     if order == 5:
         assert abs(wave.length - 354.7048) < 1e-2
-    assert abs(wave.T - 15.0) < 1e-2
+    assert abs(wave.period - 15.0) < 1e-2

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -10,8 +10,10 @@ def make_example_wave(model: str) -> WaveModel:
     height = 10.0
     depth = 200.0
     length = 100.0
-    N = 5 if model in ["Fenton", "Stokes"] else 1
-    return wave_model(height, depth, length, N)
+    kwargs: dict = {}
+    if model in ["Fenton", "Stokes"]:
+        kwargs["N"] = 5
+    return wave_model(height, depth, length, **kwargs)
 
 
 @pytest.mark.parametrize("model", WAVE_MODELS.keys())

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,0 +1,74 @@
+import pytest
+
+from raschii import WAVE_MODELS, WaveModel, get_wave_model
+
+
+def make_example_wave(model: str) -> WaveModel:
+    wave_model, _ = get_wave_model(model)
+
+    height = 10.0
+    depth = 200.0
+    length = 100.0
+    N = 5 if model in ["Fenton", "Stokes"] else 1
+    return wave_model(height, depth, length, N)
+
+
+@pytest.mark.parametrize("model", WAVE_MODELS.keys())
+def test_elevation_shape(model: str):
+    wave = make_example_wave(model)
+
+    x = wave.length / 10
+    elev = wave.surface_elevation(x)
+    assert elev.shape == (1,)
+
+    x2 = [x, x + 1, x + 2, x + 3]
+    elev2 = wave.surface_elevation(x2)
+    assert elev2.shape == (4,)
+
+    elev3 = wave.surface_elevation(x, t=[0, 1, 2])
+    assert elev3.shape == (3,)
+
+    elev4 = wave.surface_elevation(x2, t=[0, 1, 2])
+    assert elev4.shape == (3, 4)
+
+
+@pytest.mark.parametrize("model", WAVE_MODELS.keys())
+def test_velocity_shape(model: str):
+    wave = make_example_wave(model)
+
+    x = wave.length / 10
+    z = wave.   depth - 1
+    vel = wave.velocity(x, z, all_points_wet=True)
+    assert vel.shape == (2,)
+
+    x2 = [x, x + 1, x + 2, x + 3]
+    z2 = [z, z, z, z]
+    vel2 = wave.velocity(x2, z2, all_points_wet=True)
+    assert vel2.shape == (4, 2)
+
+    vel3 = wave.velocity(x, z, t=[0, 1, 2], all_points_wet=True)
+    assert vel3.shape == (3, 2)
+
+    vel4 = wave.velocity(x2, z2, t=[0, 1, 2], all_points_wet=True)
+    assert vel4.shape == (3, 4, 2)
+
+
+@pytest.mark.parametrize("model", WAVE_MODELS.keys())
+def test_velocity_potential_shape(model: str):
+    wave = make_example_wave(model)
+
+    x = wave.length / 10
+    z = wave.depth - 1
+    vp = wave.velocity_potential(x, z)
+    assert vp.shape == (1,)
+
+    x2 = [x, x + 1, x + 2, x + 3]
+    z2 = [z, z, z, z]
+    vp2 = wave.velocity_potential(x2, z2)
+    assert vp2.shape == (4,)
+
+    vp3 = wave.velocity_potential(x, z, t=[0, 1, 2])
+    assert vp3.shape == (3,)
+
+    vp4 = wave.velocity_potential(x2, z2, t=[0, 1, 2])
+    assert vp4.shape == (3, 4)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from raschii import WAVE_MODELS, WaveModel, get_wave_model
@@ -18,8 +19,11 @@ def test_elevation_shape(model: str):
     wave = make_example_wave(model)
 
     x = wave.length / 10
-    elev = wave.surface_elevation(x)
-    assert elev.shape == (1,)
+    elev0 = wave.surface_elevation(x)
+    assert np.ndim(elev0) == 0  # scalar in means scalar out
+
+    elev1 = wave.surface_elevation([x])
+    assert elev1.shape == (1,)  # array in means array out
 
     x2 = [x, x + 1, x + 2, x + 3]
     elev2 = wave.surface_elevation(x2)
@@ -59,8 +63,15 @@ def test_velocity_potential_shape(model: str):
 
     x = wave.length / 10
     z = wave.depth - 1
-    vp = wave.velocity_potential(x, z)
-    assert vp.shape == (1,)
+    vp0 = wave.velocity_potential(x, z)
+    assert np.ndim(vp0) == 0  # scalars in means scalar out
+
+    vp1a = wave.velocity_potential([x], z)
+    vp1b = wave.velocity_potential(x, [z])
+    vp1c = wave.velocity_potential([x], [z])
+    assert vp1a.shape == (1,)  # arrays in means array out 
+    assert vp1b.shape == (1,)  # arrays in means array out 
+    assert vp1c.shape == (1,)  # arrays in means array out 
 
     x2 = [x, x + 1, x + 2, x + 3]
     z2 = [z, z, z, z]

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,12 +1,11 @@
-from raschii import stokes
-
-
 def test_coefficients():
+    from raschii.wave_stokes import stokes_coefficients
+
     kd = 0.753982
 
     # First check that the higher order coefficients are zero for lower order
     for N in range(1, 6):
-        data = stokes.stokes_coefficients(kd, N)
+        data = stokes_coefficients(kd, N)
         for k, v in data.items():
             if int(k[1]) > N:
                 assert v == 0.0
@@ -48,4 +47,4 @@ def test_coefficients():
 
     # Check for overflow prevention
     for kd in range(1, 1000):
-        stokes.stokes_coefficients(kd, N)
+        stokes_coefficients(kd, N)

--- a/tests/test_wave_period.py
+++ b/tests/test_wave_period.py
@@ -41,11 +41,11 @@ def test_wave_period(wave_model_name):
     # Find the average wave period and check that it is accurate
     period = np.mean(periods)
     stdev_pst = np.std(periods) / period * 100
-    print(wave_model_name, wave_model.T, period, stdev_pst)
+    print(wave_model_name, wave_model.period, period, stdev_pst)
     assert stdev_pst < 0.6, "The standard dev should small compared to the mean"
 
     # Check period of eta vs analytical period
-    error_pst = abs(period - wave_model.T) / wave_model.T * 100
+    error_pst = abs(period - wave_model.period) / wave_model.period * 100
     print(error_pst)
     assert error_pst < 0.05, "The period should be close to the analytical"
 


### PR DESCRIPTION
New features:

- More vectorization of inputs is now implemented, you can compute elevations and velocities for multiple positions and multiple time steps at the same time). Thanks to @jasperpato in  PR #7!
  In addition @TormodLandet has added a few more vectorized methods and changed the output shape of some methods for consistency (see below).

A few **backwards incompatible** changes were made in this release:

- Rename class ``RasciiError`` to ``RaschiiError``. Also thanks to @jasperpato in  PR #7.

- Return **scalar** surface elevation (and velocity potential) when the inputs are all **scalar**.
  Previously an array with shape (1,) would be returned in this case.

  If you give arguments ``(x=1.0, t=0.0)``, the return value will be a scalar, but if you give
  ``(x=[1.0], t=0.0)`` the return value will be a 1D array with one element. This is the same
  as, e.g., numpy and scipy do for their functions, and is hence a bit more consistent.

- Move the `*_cpp` methods to a separate ``raschii.cpp`` module. If you are one of the extremely
  few users of the C++ code generator you must replace, e.g., the `wave.velocity_cpp()`  method
  with the new `wave.cpp.velocity()` method. This reduces the size of the main wave classes and
  keeps little-used functionality separate from the main code paths.